### PR TITLE
feat: create itemDef to game or anything

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/ItemController.java
+++ b/src/main/java/com/scriptopia/demo/controller/ItemController.java
@@ -1,0 +1,27 @@
+package com.scriptopia.demo.controller;
+
+import com.scriptopia.demo.domain.ItemDef;
+import com.scriptopia.demo.dto.items.ItemDefRequest;
+import com.scriptopia.demo.service.ItemDefService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/items")
+@RequiredArgsConstructor
+public class ItemController {
+
+    private final ItemDefService itemDefService;
+
+    @PostMapping
+    public ResponseEntity<ItemDef> createItem(@RequestBody ItemDefRequest dto) {
+        ItemDef savedItem = itemDefService.createItem(dto);
+        return ResponseEntity.ok(savedItem);
+    }
+
+
+}

--- a/src/main/java/com/scriptopia/demo/dto/items/ItemDefRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/items/ItemDefRequest.java
@@ -1,0 +1,32 @@
+package com.scriptopia.demo.dto.items;
+
+import com.scriptopia.demo.domain.Grade;
+import com.scriptopia.demo.domain.ItemType;
+import com.scriptopia.demo.domain.MainStat;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ItemDefRequest {
+
+    private String name;
+    private String description;
+    private String picSrc;
+
+    private ItemType itemType;
+    private MainStat mainStat;
+
+    private Integer baseStat;
+    private Integer strength;
+    private Integer agility;
+    private Integer intelligence;
+    private Integer luck;
+
+    private Long itemGradeDefId;
+    private Long price;
+
+    // 🔹 아이템 효과 리스트
+    private List<ItemEffectRequest> effects;
+
+}

--- a/src/main/java/com/scriptopia/demo/dto/items/ItemEffectRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/items/ItemEffectRequest.java
@@ -1,0 +1,12 @@
+package com.scriptopia.demo.dto.items;
+
+import com.scriptopia.demo.domain.Grade;
+import lombok.Data;
+
+@Data
+public class ItemEffectRequest {
+    private String effectName;
+    private String effectDescription;
+    private Grade grade;
+    private Integer effectValue;
+}

--- a/src/main/java/com/scriptopia/demo/service/ItemDefService.java
+++ b/src/main/java/com/scriptopia/demo/service/ItemDefService.java
@@ -1,0 +1,72 @@
+package com.scriptopia.demo.service;
+
+
+import com.scriptopia.demo.domain.EffectGradeDef;
+import com.scriptopia.demo.domain.ItemDef;
+import com.scriptopia.demo.domain.ItemEffect;
+import com.scriptopia.demo.domain.ItemGradeDef;
+import com.scriptopia.demo.dto.items.ItemDefRequest;
+import com.scriptopia.demo.dto.items.ItemEffectRequest;
+import com.scriptopia.demo.repository.EffectGradeDefRepository;
+import com.scriptopia.demo.repository.ItemDefRepository;
+import com.scriptopia.demo.repository.ItemEffectRepository;
+import com.scriptopia.demo.repository.ItemGradeDefRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ItemDefService {
+
+    private final ItemDefRepository itemDefRepository;
+    private final ItemEffectRepository itemEffectRepository;
+    private final ItemGradeDefRepository itemGradeDefRepository;
+    private final EffectGradeDefRepository effectGradeDefRepository;
+
+    @Transactional
+    public ItemDef createItem(ItemDefRequest dto) {
+        // 1️⃣ ItemGradeDef 조회
+        ItemGradeDef gradeDef = itemGradeDefRepository.findById(dto.getItemGradeDefId())
+                .orElseThrow(() -> new IllegalArgumentException("ItemGradeDef not found"));
+
+        // 2️⃣ ItemDef 생성
+        ItemDef itemDef = new ItemDef();
+        itemDef.setName(dto.getName());
+        itemDef.setDescription(dto.getDescription());
+        itemDef.setPicSrc(dto.getPicSrc());
+        itemDef.setItemType(dto.getItemType());
+        itemDef.setMainStat(dto.getMainStat());
+        itemDef.setBaseStat(dto.getBaseStat());
+        itemDef.setStrength(dto.getStrength());
+        itemDef.setAgility(dto.getAgility());
+        itemDef.setIntelligence(dto.getIntelligence());
+        itemDef.setLuck(dto.getLuck());
+        itemDef.setPrice(dto.getPrice());
+        itemDef.setItemGradeDef(gradeDef);
+        itemDef.setCreatedAt(LocalDateTime.now());
+
+        itemDefRepository.save(itemDef);
+
+        // 3️⃣ ItemEffect 생성
+        if (dto.getEffects() != null) {
+            for (ItemEffectRequest effectDto : dto.getEffects()) {
+                EffectGradeDef effectGradeDef = effectGradeDefRepository.findById(effectDto.getGrade().ordinal() + 1L)
+                        .orElseThrow(() -> new IllegalArgumentException("EffectGradeDef not found"));
+
+                ItemEffect effect = new ItemEffect();
+                effect.setItemDefs(itemDef);
+                effect.setEffectGradeDef(effectGradeDef);
+                effect.setEffectName(effectDto.getEffectName());
+                effect.setEffectValue(effectDto.getEffectValue());
+
+                itemEffectRepository.save(effect);
+            }
+        }
+
+        return itemDef;
+    }
+}


### PR DESCRIPTION
## 📑 기능 설명  
새로운 아이템을 시스템 사전에 추가할 수 있는 API입니다.  
추가된 아이템은 경매장, 인벤토리 등 시스템 전반에서 활용 가능합니다.  

## ✅ 작업할 내용  
- [x] POST /items 엔드포인트 생성  
- [x] 요청 바디 유효성 검증 (name, description, grade, mainStat 등)  
- [x] DB에 아이템 정보 저장  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 관리자가 새로운 아이템을 쉽게 시스템에 등록 가능  
- 사전에 등록된 아이템만 경매장/인벤토리에서 활용 가능  
- 중복 아이템 등록 방지로 데이터 무결성 유지  

## 📎 추가 정보  
- 엔드포인트: `POST /items`  
- 요청 바디 예시:
```json
{
  "name": "불타는 검",
  "description": "강력한 화염 속성을 가진 검",
  "grade": "rare",
  "baseStat": 50,
  "strength": 10,
  "agility": 5,
  "intelligence": 0,
  "luck": 2
}
