### PR TITLE
feat: create auction item function

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -1,5 +1,9 @@
 package com.scriptopia.demo.controller;
 
+
+import com.scriptopia.demo.dto.auction.AuctionRequest;
+import com.scriptopia.demo.dto.auction.TradeResponse;
+import com.scriptopia.demo.dto.auction.TradeFilterRequest;
 import com.scriptopia.demo.service.AuctionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,11 +16,22 @@ public class AuctionController {
 
     private final AuctionService auctionService;
 
-    @PostMapping
-    public ResponseEntity<String> createAuction(
-            @RequestBody com.scriptopia.demo.dto.auction.AuctionRequest requestDto,
-            @RequestHeader("token") String userId) {   // 헤더에서 userId 가져오기 임시임
 
-        return ResponseEntity.ok(auctionService.createAuction(requestDto, userId));
+    @PostMapping
+    public ResponseEntity<String> createAuction(@RequestBody AuctionRequest dto,
+                                                @RequestHeader("token") String userId ){   // 헤더에서 userId 가져오기 임시임
+
+        return ResponseEntity.ok(auctionService.createAuction(dto, userId));
     }
+
+
+    @GetMapping
+    public ResponseEntity<TradeResponse> getTrades(
+            @RequestBody TradeFilterRequest requestDto) {
+
+        TradeResponse response = auctionService.getTrades(requestDto);
+        return ResponseEntity.ok(response);
+
+    }
+
 }

--- a/src/main/java/com/scriptopia/demo/controller/ItemController.java
+++ b/src/main/java/com/scriptopia/demo/controller/ItemController.java
@@ -1,14 +1,14 @@
 package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.domain.ItemDef;
+import com.scriptopia.demo.dto.auction.AuctionRequest;
+import com.scriptopia.demo.dto.devlop.ItemDefResponse;
 import com.scriptopia.demo.dto.items.ItemDefRequest;
+import com.scriptopia.demo.service.AuctionService;
 import com.scriptopia.demo.service.ItemDefService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/items")
@@ -18,10 +18,12 @@ public class ItemController {
     private final ItemDefService itemDefService;
 
     @PostMapping
-    public ResponseEntity<ItemDef> createItem(@RequestBody ItemDefRequest dto) {
-        ItemDef savedItem = itemDefService.createItem(dto);
+    public ResponseEntity<ItemDefResponse> createItem(@RequestBody ItemDefRequest dto) {
+        ItemDefResponse savedItem = itemDefService.createItem(dto);
         return ResponseEntity.ok(savedItem);
     }
+
+
 
 
 }

--- a/src/main/java/com/scriptopia/demo/domain/ItemDef.java
+++ b/src/main/java/com/scriptopia/demo/domain/ItemDef.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -39,4 +41,8 @@ public class ItemDef {
     private LocalDateTime createdAt;
 
     private Long price;
+
+    @OneToMany(mappedBy = "itemDef", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ItemEffect> itemEffects = new ArrayList<>();
+
 }

--- a/src/main/java/com/scriptopia/demo/domain/ItemEffect.java
+++ b/src/main/java/com/scriptopia/demo/domain/ItemEffect.java
@@ -10,18 +10,20 @@ import lombok.Setter;
 public class ItemEffect {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue
     private Long id;
 
     // FK: ItemDefs
     @ManyToOne(fetch = FetchType.LAZY)
-    private ItemDef itemDefs;
+    private ItemDef itemDef;
 
     // FK: EffectGradeDef
     @ManyToOne(fetch = FetchType.LAZY)
     private EffectGradeDef effectGradeDef;
 
-    // 예를 들어 효과 이름이나 수치 같은 필드가 있다면 여기에 추가
+    // 예를 들어 효과 이름
     private String effectName;
-    private int effectValue;
+    
+    // 아이템 효과 설명
+    private String effect_description;
 }

--- a/src/main/java/com/scriptopia/demo/domain/User.java
+++ b/src/main/java/com/scriptopia/demo/domain/User.java
@@ -1,9 +1,6 @@
 package com.scriptopia.demo.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,6 +20,8 @@ public class User {
     private LocalDateTime lastLoginAt;
 
     private String profileImgUrl;
+
+    @Enumerated(EnumType.STRING)
     private Role role;
 
 }

--- a/src/main/java/com/scriptopia/demo/domain/UserItem.java
+++ b/src/main/java/com/scriptopia/demo/domain/UserItem.java
@@ -23,5 +23,7 @@ public class UserItem {
 
 
     private int remainingUses;
+
+    @Enumerated(EnumType.STRING)
     private TradeStatus tradeStatus;
 }

--- a/src/main/java/com/scriptopia/demo/dto/auction/AuctionItemResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/AuctionItemResponse.java
@@ -1,0 +1,50 @@
+package com.scriptopia.demo.dto.auction;
+
+import com.scriptopia.demo.domain.TradeStatus;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Data
+public class AuctionItemResponse {
+
+    private Long auctionId;
+    private Long price;
+    private LocalDateTime createdAt;
+
+    private UserDto seller;
+    private ItemDto item;
+
+    @Data
+    public static class UserDto {
+        private Long userId;
+        private String nickname;
+    }
+
+    @Data
+    public static class ItemDto {
+        private Long userItemId;
+        private Long itemDefId;
+        private String name;
+        private String description;
+        private String picSrc;
+        private int remainingUses;
+        private TradeStatus tradeStatus;
+        private String grade;
+        private int baseStat;
+        private int strength;
+        private int agility;
+        private int intelligence;
+        private int luck;
+        private List<ItemEffectDto> effects;
+    }
+
+    @Data
+    public static class ItemEffectDto {
+        private String effectName;
+        private String effectDescription;
+        private String grade;
+    }
+}

--- a/src/main/java/com/scriptopia/demo/dto/auction/AuctionRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/AuctionRequest.java
@@ -6,7 +6,6 @@ import lombok.Data;
 
 @Data
 public class AuctionRequest {
-    private String itemDefsId;
-    private TradeStatus tradeStatus; // ENUM이면 String으로 받아서 변환
+    private String itemDefId; // 단수형으로 바꿔주세요
     private Long price;
 }

--- a/src/main/java/com/scriptopia/demo/dto/auction/TradeFilterRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/TradeFilterRequest.java
@@ -1,0 +1,23 @@
+package com.scriptopia.demo.dto.auction;
+
+import com.scriptopia.demo.domain.Grade;
+import com.scriptopia.demo.domain.ItemType;
+import com.scriptopia.demo.domain.MainStat;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class TradeFilterRequest {
+
+    private Long pageIndex;   // 0부터 시작
+    private Long pageSize;    // 한 페이지당 아이템 수
+
+    private String itemName;           // 판매 아이템 이름
+    private ItemType category;         // 아이템 분류 (WEAPON, ARMOR, ARTIFACT, POTION)
+    private Long minPrice;             // 최소 가격 (nullable)
+    private Long maxPrice;             // 최대 가격 (nullable)
+    private Grade grade;               // 아이템 등급 (nullable)
+    private List<Grade> effectGrades;  // 아이템 효과 등급 필터 (nullable)
+    private MainStat mainStat;         // 주 스탯 (nullable)
+}

--- a/src/main/java/com/scriptopia/demo/dto/auction/TradeResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/TradeResponse.java
@@ -1,0 +1,19 @@
+// PagedAuctionResponse.java
+package com.scriptopia.demo.dto.auction;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class TradeResponse {
+    private List<AuctionItemResponse> content;
+    private PageInfo pageInfo;
+
+    @Data
+    public static class PageInfo {
+        private int currentPage;
+        private int pageSize;
+        private long totalItems;
+        private int totalPages;
+    }
+}

--- a/src/main/java/com/scriptopia/demo/dto/devlop/ItemDefResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/devlop/ItemDefResponse.java
@@ -1,0 +1,26 @@
+package com.scriptopia.demo.dto.devlop;
+
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class ItemDefResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private String picSrc;
+    private String itemType;       // enum 대신 String으로 전달
+    private String mainStat;       // enum 대신 String
+    private Integer baseStat;
+    private Integer strength;
+    private Integer agility;
+    private Integer intelligence;
+    private Integer luck;
+    private Long price;
+    private LocalDateTime createdAt;
+
+    private List<ItemEffectResponse> effects;
+}

--- a/src/main/java/com/scriptopia/demo/dto/devlop/ItemEffectResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/devlop/ItemEffectResponse.java
@@ -1,0 +1,10 @@
+package com.scriptopia.demo.dto.devlop;
+
+import lombok.Data;
+
+@Data
+public class ItemEffectResponse {
+    private String effectName;
+    private String effectDescription;
+    private String grade;   // enum 대신 String
+}

--- a/src/main/java/com/scriptopia/demo/dto/items/ItemEffectRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/items/ItemEffectRequest.java
@@ -8,5 +8,4 @@ public class ItemEffectRequest {
     private String effectName;
     private String effectDescription;
     private Grade grade;
-    private Integer effectValue;
 }

--- a/src/main/java/com/scriptopia/demo/repository/AuctionRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/AuctionRepository.java
@@ -1,9 +1,64 @@
 package com.scriptopia.demo.repository;
 
-import com.scriptopia.demo.domain.Auction;
-import com.scriptopia.demo.domain.UserItem;
+import com.scriptopia.demo.domain.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
     boolean existsByUserItem(UserItem userItem);
+
+
+    // itemName 우선 검색 (연관 테이블 조인)
+    @Query("""
+        SELECT DISTINCT a FROM Auction a
+        JOIN FETCH a.userItem ui
+        JOIN FETCH ui.user u
+        JOIN FETCH ui.itemDef idf
+        LEFT JOIN FETCH idf.itemEffects ie
+        LEFT JOIN FETCH ie.effectGradeDef e
+        WHERE LOWER(idf.name) LIKE LOWER(CONCAT('%', :itemName, '%'))
+        ORDER BY a.createdAt DESC
+        """)
+    Page<Auction> findByItemName(@Param("itemName") String itemName, Pageable pageable);
+
+
+    // 필터 조건 검색 (itemName 없는 경우)
+    @Query("""
+    SELECT DISTINCT a
+    FROM Auction a
+    JOIN a.userItem ui
+    JOIN ui.itemDef id
+    LEFT JOIN id.itemEffects ie
+    WHERE (:category IS NULL OR id.itemType = :category)
+      AND (:grade IS NULL OR id.itemGradeDef.grade = :grade)
+      AND (:minPrice IS NULL OR a.price >= :minPrice)
+      AND (:maxPrice IS NULL OR a.price <= :maxPrice)
+      AND (:mainStat IS NULL OR id.mainStat = :mainStat)
+      AND (
+            :effectGrades IS NULL 
+            OR EXISTS (
+                SELECT 1 FROM ItemEffect ie2 
+                WHERE ie2.itemDef = id 
+                AND ie2.effectGradeDef.grade IN :effectGrades
+            )
+      )
+""")
+    Page<Auction> findByFilters(
+            @Param("category") ItemType category,
+            @Param("grade") Grade grade,
+            @Param("minPrice") Long minPrice,
+            @Param("maxPrice") Long maxPrice,
+            @Param("mainStat") MainStat mainStat,
+            @Param("effectGrades") List<Grade> effectGrades,
+            Pageable pageable
+    );
+
+
+
 }

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -4,16 +4,27 @@ import com.scriptopia.demo.domain.Auction;
 import com.scriptopia.demo.domain.TradeStatus;
 import com.scriptopia.demo.domain.UserItem;
 import com.scriptopia.demo.dto.auction.AuctionRequest;
+import com.scriptopia.demo.dto.auction.AuctionItemResponse;
+import com.scriptopia.demo.dto.auction.TradeResponse;
+import com.scriptopia.demo.dto.auction.TradeFilterRequest;
 import com.scriptopia.demo.repository.AuctionRepository;
 import com.scriptopia.demo.repository.UserItemRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuctionService {
 
     private final AuctionRepository auctionRepository;
@@ -25,7 +36,7 @@ public class AuctionService {
         // UUID(String) → Long 변환 (임시)
         long userItemId;
         try {
-            userItemId = Long.parseLong(requestDto.getItemDefsId());
+            userItemId = Long.parseLong(requestDto.getItemDefId());
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid UserItem UUID");
         }
@@ -63,4 +74,108 @@ public class AuctionService {
 
         return "등록 완료: 가격=" + requestDto.getPrice();
     }
+
+
+
+
+    public TradeResponse getTrades(TradeFilterRequest request){
+        int page = request.getPageIndex().intValue();
+        int size = request.getPageSize().intValue();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<Auction> auctionPage;
+        if (request.getItemName() != null && !request.getItemName().isEmpty()) {
+            // itemName으로 검색, 연관 테이블까지 fetch
+            auctionPage = auctionRepository.findByItemName(request.getItemName(), pageable);
+        } else {
+            // 이름이 없으면 다른 필터 조건으로 검색
+            auctionPage = auctionRepository.findByFilters(
+                    request.getCategory(),
+                    request.getGrade(),
+                    request.getMinPrice(),
+                    request.getMaxPrice(),
+                    request.getMainStat(),
+                    request.getEffectGrades(),
+                    pageable
+            );
+        }
+
+
+
+        List<AuctionItemResponse> items = auctionPage.stream()
+                .map(a -> {
+                    AuctionItemResponse dto = new AuctionItemResponse();
+                    dto.setAuctionId(a.getId());
+                    dto.setPrice(a.getPrice());
+                    dto.setCreatedAt(a.getCreatedAt());
+
+                    // seller 정보
+                    AuctionItemResponse.UserDto userDto = new AuctionItemResponse.UserDto();
+                    userDto.setUserId(a.getUserItem().getUser().getId());
+                    userDto.setNickname(a.getUserItem().getUser().getNickname());
+                    dto.setSeller(userDto);
+
+                    // item 정보
+                    AuctionItemResponse.ItemDto itemDto = new AuctionItemResponse.ItemDto();
+                    itemDto.setUserItemId(a.getUserItem().getId());
+                    itemDto.setItemDefId(a.getUserItem().getItemDef().getId());
+                    itemDto.setName(a.getUserItem().getItemDef().getName());
+                    itemDto.setDescription(a.getUserItem().getItemDef().getDescription());
+                    itemDto.setPicSrc(a.getUserItem().getItemDef().getPicSrc());
+                    itemDto.setRemainingUses(a.getUserItem().getRemainingUses());
+                    itemDto.setTradeStatus(a.getUserItem().getTradeStatus());
+                    itemDto.setGrade(String.valueOf(a.getUserItem().getItemDef().getItemGradeDef().getGrade()));
+                    itemDto.setBaseStat(a.getUserItem().getItemDef().getBaseStat());
+                    itemDto.setStrength(a.getUserItem().getItemDef().getStrength());
+                    itemDto.setAgility(a.getUserItem().getItemDef().getAgility());
+                    itemDto.setIntelligence(a.getUserItem().getItemDef().getIntelligence());
+                    itemDto.setLuck(a.getUserItem().getItemDef().getLuck());
+
+                    // 효과 리스트 → 조건과 관계없이 "모든 효과"를 포함
+                    // (JPQL에서 한 개만 남았더라도, Hibernate 엔티티를 통해 전체 컬렉션 다시 로딩)
+                    a.getUserItem().getItemDef().getItemEffects().size(); // lazy 초기화 강제
+
+                    List<AuctionItemResponse.ItemEffectDto> effects =
+                            a.getUserItem().getItemDef().getItemEffects().stream()
+                                    .map(e -> {
+                                        AuctionItemResponse.ItemEffectDto effDto = new AuctionItemResponse.ItemEffectDto();
+                                        effDto.setEffectName(e.getEffectName());
+                                        effDto.setEffectDescription(e.getEffect_description());
+                                        effDto.setGrade(e.getEffectGradeDef().getGrade().name());
+                                        return effDto;
+                                    })
+                                    .toList();
+
+                    itemDto.setEffects(effects);
+                    dto.setItem(itemDto);
+
+                    return dto;
+                })
+                .toList();
+
+
+        TradeResponse response = new TradeResponse();
+        response.setContent(items);
+
+        TradeResponse.PageInfo pageInfo = new TradeResponse.PageInfo();
+        pageInfo.setCurrentPage(auctionPage.getNumber());        // 현재 페이지
+        pageInfo.setPageSize(auctionPage.getSize());            // 페이지 당 항목 수
+        pageInfo.setTotalPages(auctionPage.getTotalPages());    // 전체 페이지 수
+        pageInfo.setTotalItems(auctionPage.getTotalElements()); // 전체 아이템 수
+
+        response.setPageInfo(pageInfo);
+
+        return response;
+
+
+    }
+
+
+
+
+
+
+
+
+
 }

--- a/src/main/java/com/scriptopia/demo/service/ItemDefService.java
+++ b/src/main/java/com/scriptopia/demo/service/ItemDefService.java
@@ -1,39 +1,39 @@
 package com.scriptopia.demo.service;
 
-
 import com.scriptopia.demo.domain.EffectGradeDef;
 import com.scriptopia.demo.domain.ItemDef;
 import com.scriptopia.demo.domain.ItemEffect;
 import com.scriptopia.demo.domain.ItemGradeDef;
-import com.scriptopia.demo.dto.items.ItemDefRequest;
-import com.scriptopia.demo.dto.items.ItemEffectRequest;
+import com.scriptopia.demo.dto.devlop.ItemDefResponse;
+import com.scriptopia.demo.dto.devlop.ItemEffectResponse;
+import com.scriptopia.demo.dto.items.*;
 import com.scriptopia.demo.repository.EffectGradeDefRepository;
 import com.scriptopia.demo.repository.ItemDefRepository;
-import com.scriptopia.demo.repository.ItemEffectRepository;
 import com.scriptopia.demo.repository.ItemGradeDefRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ItemDefService {
 
     private final ItemDefRepository itemDefRepository;
-    private final ItemEffectRepository itemEffectRepository;
     private final ItemGradeDefRepository itemGradeDefRepository;
     private final EffectGradeDefRepository effectGradeDefRepository;
 
     @Transactional
-    public ItemDef createItem(ItemDefRequest dto) {
-        // 1️⃣ ItemGradeDef 조회
+    public ItemDefResponse createItem(ItemDefRequest dto) {
+        // ItemGradeDef 조회
         ItemGradeDef gradeDef = itemGradeDefRepository.findById(dto.getItemGradeDefId())
                 .orElseThrow(() -> new IllegalArgumentException("ItemGradeDef not found"));
 
-        // 2️⃣ ItemDef 생성
+        // ItemDef 생성
         ItemDef itemDef = new ItemDef();
         itemDef.setName(dto.getName());
         itemDef.setDescription(dto.getDescription());
@@ -49,24 +49,58 @@ public class ItemDefService {
         itemDef.setItemGradeDef(gradeDef);
         itemDef.setCreatedAt(LocalDateTime.now());
 
-        itemDefRepository.save(itemDef);
-
-        // 3️⃣ ItemEffect 생성
+        // ItemEffect 생성
         if (dto.getEffects() != null) {
             for (ItemEffectRequest effectDto : dto.getEffects()) {
                 EffectGradeDef effectGradeDef = effectGradeDefRepository.findById(effectDto.getGrade().ordinal() + 1L)
                         .orElseThrow(() -> new IllegalArgumentException("EffectGradeDef not found"));
 
                 ItemEffect effect = new ItemEffect();
-                effect.setItemDefs(itemDef);
+                effect.setItemDef(itemDef);
                 effect.setEffectGradeDef(effectGradeDef);
                 effect.setEffectName(effectDto.getEffectName());
-                effect.setEffectValue(effectDto.getEffectValue());
+                effect.setEffect_description(effectDto.getEffectDescription());
 
-                itemEffectRepository.save(effect);
+                itemDef.getItemEffects().add(effect);
             }
         }
 
-        return itemDef;
+        // ItemDef 저장 (cascade로 ItemEffect도 같이 저장)
+        itemDefRepository.save(itemDef);
+
+        // DTO 변환 후 반환
+        return toResponse(itemDef);
+    }
+
+    // ================== DTO 변환 ==================
+    private ItemDefResponse toResponse(ItemDef itemDef) {
+        ItemDefResponse response = new ItemDefResponse();
+        response.setId(itemDef.getId());
+        response.setName(itemDef.getName());
+        response.setDescription(itemDef.getDescription());
+        response.setPicSrc(itemDef.getPicSrc());
+        response.setItemType(itemDef.getItemType().name());
+        response.setMainStat(itemDef.getMainStat().name());
+        response.setBaseStat(itemDef.getBaseStat());
+        response.setStrength(itemDef.getStrength());
+        response.setAgility(itemDef.getAgility());
+        response.setIntelligence(itemDef.getIntelligence());
+        response.setLuck(itemDef.getLuck());
+        response.setPrice(itemDef.getPrice());
+        response.setCreatedAt(itemDef.getCreatedAt());
+
+        List<ItemEffectResponse> effects = itemDef.getItemEffects().stream()
+                .map(effect -> {
+                    ItemEffectResponse eResp = new ItemEffectResponse();
+                    eResp.setEffectName(effect.getEffectName());
+                    eResp.setEffectDescription(effect.getEffect_description());
+                    eResp.setGrade(effect.getEffectGradeDef().getGrade().name());
+                    return eResp;
+                })
+                .collect(Collectors.toList());
+
+        response.setEffects(effects);
+
+        return response;
     }
 }


### PR DESCRIPTION
## 📑 기능 설명
전체 판매 중인 경매 아이템을 조회하는 API입니다.
사용자는 페이지네이션을 통해 한 번에 일정 수의 판매 아이템 목록을 가져올 수 있으며, 판매 중인 아이템만 조회됩니다.

## ✅ 작업할 내용
- [x] GET /trades 엔드포인트 생성
- [x] 페이지네이션 적용 (pageIndex, pageSize)
- [x] 판매 중인 아이템만 조회
- [x] 응답 DTO(TradeResponse)
- [x] 성공/에러 응답 포맷 적용

## 🎈 기대 효과
- 클라이언트에서 전체 판매 아이템 목록 확인 가능
- 페이지네이션으로 한 번에 가져오는 데이터 양 조절 가능
- 거래가 완료되지 않은 아이템만 조회되어 정확한 판매 현황 제공

## 📎 추가 정보
- 기본 정렬: 등록 시각 기준 내림차순
- 필터 미적용: 전체 판매 아이템 조회
