### PR TITLE
[Feature] 공유 게임 저장

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -1,0 +1,20 @@
+package com.scriptopia.demo.controller;
+
+import com.scriptopia.demo.domain.SharedGame;
+import com.scriptopia.demo.service.SharedGameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class SharedGameController {
+    private final SharedGameService sharedGameService;
+
+    @PostMapping("/share/{id}")
+    public ResponseEntity<?> share(@RequestHeader(value = "Authorization")String token,
+                                   @PathVariable Long Id) {
+        return sharedGameService.saveSharedGame(token, Id);
+    }
+}

--- a/src/main/java/com/scriptopia/demo/domain/SharedGame.java
+++ b/src/main/java/com/scriptopia/demo/domain/SharedGame.java
@@ -1,7 +1,9 @@
 package com.scriptopia.demo.domain;
 
+import com.scriptopia.demo.dto.sharedgame.SharedGameRequest;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
@@ -10,6 +12,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
+@NoArgsConstructor
 public class SharedGame {
     @Id
     @GeneratedValue
@@ -20,10 +23,28 @@ public class SharedGame {
     private User user;
 
     private String thumbnailUrl;
-    private Long recommend;
-    private Long totalPlayed;
+    private Long recommend = 0L;
+    private Long totalPlayed = 0L;
+
+    @Column(columnDefinition = "TEXT")
     private String title;
+
+    @Column(columnDefinition = "TEXT")
     private String worldView;
+
+    @Column(columnDefinition = "TEXT")
     private String backgroundStory;
     private LocalDateTime sharedAt;
+
+    public static SharedGame from(User user, History h) {
+        SharedGame game = new SharedGame();
+        game.user = user;
+        game.thumbnailUrl = h.getThumbnailUrl();
+        game.title = h.getTitle();
+        game.worldView = h.getWorldView();
+        game.backgroundStory = h.getBackgroundStory();
+        game.sharedAt = LocalDateTime.now();
+
+        return game;
+    }
 }

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/SharedGameRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/SharedGameRequest.java
@@ -1,0 +1,15 @@
+package com.scriptopia.demo.dto.sharedgame;
+
+import com.scriptopia.demo.domain.User;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class SharedGameRequest {
+    private Long userId;
+    private String thumbnail_url;
+    private String title;
+    private String world_view;
+    private String background_story;
+}

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -38,5 +38,6 @@ public class SharedGameService {
 
         SharedGame sharedGame = SharedGame.from(user, history);
         return ResponseEntity.ok(sharedGameRepository.save(sharedGame));
+
     }
 }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -39,5 +39,6 @@ public class SharedGameService {
         SharedGame sharedGame = SharedGame.from(user, history);
         return ResponseEntity.ok(sharedGameRepository.save(sharedGame));
 
+
     }
 }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -1,0 +1,42 @@
+package com.scriptopia.demo.service;
+
+import com.scriptopia.demo.domain.History;
+import com.scriptopia.demo.domain.SharedGame;
+import com.scriptopia.demo.domain.User;
+import com.scriptopia.demo.dto.sharedgame.SharedGameRequest;
+import com.scriptopia.demo.repository.HistoryRepository;
+import com.scriptopia.demo.repository.SharedGameRepository;
+import com.scriptopia.demo.repository.UserRepository;
+import com.scriptopia.demo.utils.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SharedGameService {
+    private final SharedGameRepository sharedGameRepository;
+    private final HistoryRepository historyRepository;
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ResponseEntity<?> saveSharedGame(String header, Long historyId) {
+        Long userId = jwtProvider.getUserId(header);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        History history = historyRepository.findById(historyId)
+                .orElseThrow(() -> new RuntimeException("History not found"));
+
+        if(!history.getUser().getId().equals(userId)) {
+            return ResponseEntity.status(403).body("not your history");
+        }
+
+        SharedGame sharedGame = SharedGame.from(user, history);
+        return ResponseEntity.ok(sharedGameRepository.save(sharedGame));
+    }
+}


### PR DESCRIPTION
## 🚀 관련 이슈

Close #61 

## 📑 PR 설명
사용자가 플레이했던 게임 기록을 공유해서 shared_game 테이블에 저장하는 기능

## ✏️ 작업 내용
SharedGame , service, DTO, Controller 구성

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 내 히스토리를 다른 사용자와 공유할 수 있는 기능이 추가되었습니다. 인증된 사용자만 자신의 히스토리를 공유할 수 있으며, 성공 시 공유된 항목 정보가 응답으로 제공됩니다.
  - 제목·세계관·배경 이야기 등 긴 텍스트를 안정적으로 저장·표시할 수 있도록 텍스트 처리 용량이 확장되었습니다.
  - 공유 항목의 추천 수와 플레이 수가 기본값으로 초기화되어 일관된 집계가 보장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->