### PR TITLE
[Feature] 공유한 게임 삭제

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -17,4 +17,10 @@ public class SharedGameController {
                                    @PathVariable Long Id) {
         return sharedGameService.saveSharedGame(token, Id);
     }
+
+    @DeleteMapping("/share/{id}")
+    public void delete(@RequestHeader(value = "Authorization")String token,
+                                @PathVariable Long gameId) {
+        sharedGameService.deletesharedGame(token, gameId);
+    }
 }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -38,7 +38,22 @@ public class SharedGameService {
 
         SharedGame sharedGame = SharedGame.from(user, history);
         return ResponseEntity.ok(sharedGameRepository.save(sharedGame));
+    }
 
+    @Transactional
+    public void deletesharedGame(String header, Long sharedId) {
+        Long userId = jwtProvider.getUserId(header);
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        SharedGame game = sharedGameRepository.findById(sharedId)
+                .orElseThrow(() -> new RuntimeException("Shared game not found"));
+
+        if(!game.getUser().getId().equals(userId)) {        // 공유된 게임과 로그인한 사용자가 아닌 경우
+            new RuntimeException("User not your history");
+        }
+
+        sharedGameRepository.delete(game);
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈

Close #63 

## 📑 PR 설명
사용자가 이전에 공유한 게임 기록(SharedGame)을 삭제하는 기능
삭제 시, 해당 게임은 더 이상 다른 사용자에게 보이지 않으며 공유 목록에서도 제거된다.

## ✏️ 작업 내용
Service 로직 추가, Controller 로직 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 공유된 게임을 삭제(공유 해제)할 수 있는 기능이 추가되었습니다. 권한 인증 후 삭제가 처리되며, 삭제 즉시 다른 사용자에게 더 이상 노출되지 않습니다. 앱/클라이언트에서 ‘삭제’ 또는 ‘공유 해제’ 동작을 사용할 수 있어, 내 공유 관리에 대한 유연한 제어가 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->