### PR TITLE
[Feature] 공유한 게임 삭제

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/HistoryController.java
+++ b/src/main/java/com/scriptopia/demo/controller/HistoryController.java
@@ -6,12 +6,13 @@ import com.scriptopia.demo.repository.UserRepository;
 import com.scriptopia.demo.service.HistoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/games")
+@RequestMapping("/users/games")
 @RequiredArgsConstructor
 public class HistoryController {
     private final HistoryService historyService;
@@ -20,9 +21,11 @@ public class HistoryController {
      * 현재는 userId, sessionId를 통해 저장하는데
      * 인증 관리 부분 끝나면 header에 token 꺼내오고 requestparameter session_id로 저장하게 수정
      */
-    @PostMapping("/{id}/history/{sid}")
-    public ResponseEntity<?> addHistory(@PathVariable Long id, @PathVariable String sid) {
-        return historyService.createHistory(id, sid);
+    @PostMapping("/{sid}/history")
+    public ResponseEntity<?> addHistory(@PathVariable String sid, Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return historyService.createHistory(userId, sid);
     }
 
     /** 개발용: 로컬 MongoDB에 더미 세션 한 건 심어서 테스트용 ObjectId 반환 */

--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -4,6 +4,7 @@ import com.scriptopia.demo.domain.SharedGame;
 import com.scriptopia.demo.service.SharedGameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -12,15 +13,17 @@ import org.springframework.web.bind.annotation.*;
 public class SharedGameController {
     private final SharedGameService sharedGameService;
 
-    @PostMapping("/share/{id}")
-    public ResponseEntity<?> share(@RequestHeader(value = "Authorization")String token,
-                                   @PathVariable Long Id) {
-        return sharedGameService.saveSharedGame(token, Id);
+    @PostMapping("/share/{hid}")
+    public ResponseEntity<?> share(Authentication authentication, @PathVariable Long hid) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return sharedGameService.saveSharedGame(userId, hid);
     }
 
-    @DeleteMapping("/share/{id}")
-    public void delete(@RequestHeader(value = "Authorization")String token,
-                                @PathVariable Long gameId) {
-        sharedGameService.deletesharedGame(token, gameId);
+    @DeleteMapping("/share/{gameid}")
+    public void delete(Authentication authentication, @PathVariable Long gameid) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        sharedGameService.deletesharedGame(userId, gameid);
     }
 }

--- a/src/main/java/com/scriptopia/demo/controller/UserHistoryController.java
+++ b/src/main/java/com/scriptopia/demo/controller/UserHistoryController.java
@@ -5,20 +5,23 @@ import com.scriptopia.demo.dto.history.HistoryResponse;
 import com.scriptopia.demo.service.HistoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping("/public")
 @RequiredArgsConstructor
 public class UserHistoryController {
     private final HistoryService historyService;
 
     @GetMapping("/history")
-    public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestHeader("X-User-ID") Long userId,
-                                                                @RequestParam(required = false) Long lastId,
-                                                                @RequestParam(defaultValue = "10") int size) {
+    public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) Long lastId,
+                                                                @RequestParam(defaultValue = "10") int size,
+                                                                @RequestParam Long userId) {
+//        Long userId = Long.valueOf(authentication.getName());
+
         return historyService.fetchMyHisotry(userId, lastId, size);
     }
 }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -23,16 +23,14 @@ public class SharedGameService {
     private final UserRepository userRepository;
 
     @Transactional
-    public ResponseEntity<?> saveSharedGame(String header, Long historyId) {
-        Long userId = jwtProvider.getUserId(header);
-
-        User user = userRepository.findById(userId)
+    public ResponseEntity<?> saveSharedGame(Long Id, Long historyId) {
+        User user = userRepository.findById(Id)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         History history = historyRepository.findById(historyId)
                 .orElseThrow(() -> new RuntimeException("History not found"));
 
-        if(!history.getUser().getId().equals(userId)) {
+        if(!history.getUser().getId().equals(Id)) {
             return ResponseEntity.status(403).body("not your history");
         }
 
@@ -41,17 +39,15 @@ public class SharedGameService {
     }
 
     @Transactional
-    public void deletesharedGame(String header, Long sharedId) {
-        Long userId = jwtProvider.getUserId(header);
-
-        User user = userRepository.findById(userId)
+    public void deletesharedGame(Long id, Long sharedId) {
+        User user = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         SharedGame game = sharedGameRepository.findById(sharedId)
                 .orElseThrow(() -> new RuntimeException("Shared game not found"));
 
-        if(!game.getUser().getId().equals(userId)) {        // 공유된 게임과 로그인한 사용자가 아닌 경우
-            new RuntimeException("User not your history");
+        if(!game.getUser().getId().equals(user.getId())) {        // 공유된 게임과 로그인한 사용자가 아닌 경우
+            throw new RuntimeException("User not your history");
         }
 
         sharedGameRepository.delete(game);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api/v1
+
 spring:
   config:
     import: optional:file:.env[.properties]


### PR DESCRIPTION
## 🚀 관련 이슈

Close #63 

## 📑 PR 설명
내가 공유한 게임 삭제 기능(자신이 공유한 것만 삭제 가능하도록 로직 추가, API 테스트)
예외처리는 이후 추가적으로 구성해야함

## ✏️ 작업 내용
Service 로직 수정, Api 엔드포인트 수정(users)

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 모든 엔드포인트가 /api/v1 하위 경로로 제공됩니다.
  - 공유/히스토리 관련 엔드포인트가 인증 컨텍스트에서 사용자 식별을 자동으로 가져옵니다(헤더 토큰/사용자 ID 전달 불필요).

- 변경 사항
  - 사용자 히스토리 조회 경로가 /public/history 로 이동하고, userId를 헤더가 아닌 쿼리 파라미터로 받습니다.
  - 일부 게임/히스토리 관련 경로가 조정되었습니다(예: 사용자 기반 경로 정리).

- 버그 수정
  - 소유자 확인 로직을 강화하여 권한 없는 요청에 대해 올바르게 403을 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->