### PR TITLE
Feature/77 verify email

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/AuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuthController.java
@@ -34,6 +34,8 @@ public class AuthController {
     @PostMapping("/public/auth/verify-email")
     public ResponseEntity<?> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
 
+        localAccountService.verifyEmail(request);
+
         return ResponseEntity.ok("사용 가능한 이메일입니다.");
     }
 

--- a/src/main/java/com/scriptopia/demo/controller/AuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuthController.java
@@ -31,6 +31,12 @@ public class AuthController {
     private static final String COOKIE_SAMESITE = "None";
 
 
+    @PostMapping("/public/auth/verify-email")
+    public ResponseEntity<?> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
+
+        return ResponseEntity.ok("사용 가능한 이메일입니다.");
+    }
+
     @PostMapping("/public/auth/login")
     public ResponseEntity<LoginResponse> login(
             @RequestBody @Valid LoginRequest req,

--- a/src/main/java/com/scriptopia/demo/controller/AuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuthController.java
@@ -30,6 +30,7 @@ public class AuthController {
     private static final boolean COOKIE_SECURE = true;
     private static final String COOKIE_SAMESITE = "None";
 
+
     @PostMapping("/public/auth/login")
     public ResponseEntity<LoginResponse> login(
             @RequestBody @Valid LoginRequest req,

--- a/src/main/java/com/scriptopia/demo/dto/localaccount/VerifyEmailRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/localaccount/VerifyEmailRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class verifyEmailRequest {
+public class VerifyEmailRequest {
 
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
     @Email(message = "올바른 이메일 형식이 아닙니다.")

--- a/src/main/java/com/scriptopia/demo/dto/localaccount/verifyEmailRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/localaccount/verifyEmailRequest.java
@@ -1,0 +1,17 @@
+package com.scriptopia.demo.dto.localaccount;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class verifyEmailRequest {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 server:
   servlet:
     context-path: /api/v1
+  error:
+    whitelabel:
+      enabled: false   # 톰캣/화이트라벨 HTML 끄기(우리가 직접 분기하므로)
 
 spring:
   config:
@@ -12,7 +15,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
@@ -44,8 +47,4 @@ auth:
     refresh-exp-seconds: 1209600
     secret: ${JWT_SECRET}
 
-server:
-  error:
-    whitelabel:
-      enabled: false   # 톰캣/화이트라벨 HTML 끄기(우리가 직접 분기하므로)
 


### PR DESCRIPTION
## 🚀 관련 이슈

Close #77 

## 📑 PR 설명
회원가입 시 이메일 중복 검증
## ✏️ 작업 내용
 - 이메일 공백, 형식 예외 처리
 - 이메일 중복 예외 처리
 - 에러 코드 생성
## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 빌드 통과 확인
- [x] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 이메일 사용 가능 여부를 확인하는 공개 API(POST /public/auth/verify-email)를 추가했습니다. 유효한 이메일이면 200 응답과 안내 메시지를 반환합니다.
- 개선
  - 회원가입 시 중복 이메일을 사전 감지하여 더 빠르게 안내합니다.
  - 이메일 형식/필수 입력에 대한 검증 메시지를 한국어로 명확히 제공합니다.
- 작업
  - 애플리케이션 DB 스키마 전략을 create에서 update로 전환하여 재시작 시 데이터 보존을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->