### PR TITLE
Feature/25 get my settlement page

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -1,10 +1,7 @@
 package com.scriptopia.demo.controller;
 
 
-import com.scriptopia.demo.dto.auction.AuctionRequest;
-import com.scriptopia.demo.dto.auction.SettlementHistoryRequest;
-import com.scriptopia.demo.dto.auction.TradeResponse;
-import com.scriptopia.demo.dto.auction.TradeFilterRequest;
+import com.scriptopia.demo.dto.auction.*;
 import com.scriptopia.demo.service.AuctionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -62,13 +59,13 @@ public class AuctionController {
 
 
     @GetMapping("/user/trades/me/history")
-    public ResponseEntity<String> settlementHistory(
+    public ResponseEntity<SettlementHistoryResponse> settlementHistory(
             @RequestBody SettlementHistoryRequest requestDto,
             Authentication authentication) {
 
 
         Long userId = Long.valueOf(authentication.getName());
-        String result = auctionService.settlementHistory(userId, requestDto);
+        SettlementHistoryResponse result = auctionService.settlementHistory(userId, requestDto);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -2,11 +2,11 @@ package com.scriptopia.demo.controller;
 
 
 import com.scriptopia.demo.dto.auction.AuctionRequest;
+import com.scriptopia.demo.dto.auction.SettlementHistoryRequest;
 import com.scriptopia.demo.dto.auction.TradeResponse;
 import com.scriptopia.demo.dto.auction.TradeFilterRequest;
 import com.scriptopia.demo.service.AuctionService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -59,6 +59,18 @@ public class AuctionController {
         return ResponseEntity.ok(result);
     }
 
+
+
+    @GetMapping("/user/trades/me/history")
+    public ResponseEntity<String> settlementHistory(
+            @RequestBody SettlementHistoryRequest requestDto,
+            Authentication authentication) {
+
+
+        Long userId = Long.valueOf(authentication.getName());
+        String result = auctionService.settlementHistory(userId, requestDto);
+        return ResponseEntity.ok(result);
+    }
 
 
 }

--- a/src/main/java/com/scriptopia/demo/dto/auction/AuctionItemResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/AuctionItemResponse.java
@@ -1,13 +1,17 @@
 package com.scriptopia.demo.dto.auction;
 
 import com.scriptopia.demo.domain.TradeStatus;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class AuctionItemResponse {
 
     private Long auctionId;
@@ -18,12 +22,16 @@ public class AuctionItemResponse {
     private ItemDto item;
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class UserDto {
         private Long userId;
         private String nickname;
     }
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ItemDto {
         private Long userItemId;
         private Long itemDefId;
@@ -42,6 +50,8 @@ public class AuctionItemResponse {
     }
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ItemEffectDto {
         private String effectName;
         private String effectDescription;

--- a/src/main/java/com/scriptopia/demo/dto/auction/SettlementHistoryRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/SettlementHistoryRequest.java
@@ -1,7 +1,6 @@
 package com.scriptopia.demo.dto.auction;
 
 
-import com.scriptopia.demo.domain.TradeStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class AuctionRequest {
-    private String itemDefId; // 단수형으로 변경함
-    private Long price;
+public class SettlementHistoryRequest {
+        private Long pageIndex;
+        private Long pageSize;
 }

--- a/src/main/java/com/scriptopia/demo/dto/auction/SettlementHistoryResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/SettlementHistoryResponse.java
@@ -1,0 +1,21 @@
+package com.scriptopia.demo.dto.auction;
+
+import lombok.*;
+
+import java.util.List;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SettlementHistoryResponse {
+    private List<SettlementHistoryResponseItem> content;
+    private PageInfo pageInfo;
+
+
+    @Data
+    public static class PageInfo {
+        private int currentPage;
+        private int pageSize;
+    }
+}

--- a/src/main/java/com/scriptopia/demo/dto/auction/SettlementHistoryResponseItem.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/SettlementHistoryResponseItem.java
@@ -1,0 +1,17 @@
+package com.scriptopia.demo.dto.auction;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SettlementHistoryResponseItem {
+    private Long settlementId;
+    private String itemName;
+    private String itemType;
+    private String itemGrade;
+    private Long price;
+    private String tradeType; // BUY / SELL
+    private LocalDateTime settledAt;
+}

--- a/src/main/java/com/scriptopia/demo/repository/SettlementRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SettlementRepository.java
@@ -2,7 +2,12 @@ package com.scriptopia.demo.repository;
 
 import com.scriptopia.demo.domain.PiaItem;
 import com.scriptopia.demo.domain.Settlement;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+
+    // userId 기준으로 페이징 조회
+    Page<Settlement> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -277,6 +277,7 @@ public class AuctionService {
         // 1. userId 으로 Settlement 조회
         Page<Settlement> settlements = settlementRepository.findByUserId(userId, pageable);
 
+
         // 2. Settlement → SettlementHistoryResponseItem 변환
         List<SettlementHistoryResponseItem> content = settlements.stream()
                 .map(s -> new SettlementHistoryResponseItem(

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -1,10 +1,7 @@
 package com.scriptopia.demo.service;
 
 import com.scriptopia.demo.domain.*;
-import com.scriptopia.demo.dto.auction.AuctionRequest;
-import com.scriptopia.demo.dto.auction.AuctionItemResponse;
-import com.scriptopia.demo.dto.auction.TradeResponse;
-import com.scriptopia.demo.dto.auction.TradeFilterRequest;
+import com.scriptopia.demo.dto.auction.*;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.AuctionRepository;
@@ -270,6 +267,15 @@ public class AuctionService {
         return "정산이 완료되었습니다.";
     }
 
+
+
+    public TradeResponse settlementHistory(Long userId, SettlementHistoryRequest requestDto) {
+        int page = requestDto.getPageIndex().intValue();
+        int size = requestDto.getPageSize().intValue();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+
+    }
 
 
 }

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -269,11 +269,34 @@ public class AuctionService {
 
 
 
-    public TradeResponse settlementHistory(Long userId, SettlementHistoryRequest requestDto) {
+    public SettlementHistoryResponse settlementHistory(Long userId, SettlementHistoryRequest requestDto) {
         int page = requestDto.getPageIndex().intValue();
         int size = requestDto.getPageSize().intValue();
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
 
+        // 1. userId 으로 Settlement 조회
+        Page<Settlement> settlements = settlementRepository.findByUserId(userId, pageable);
+
+        // 2. Settlement → SettlementHistoryResponseItem 변환
+        List<SettlementHistoryResponseItem> content = settlements.stream()
+                .map(s -> new SettlementHistoryResponseItem(
+                        s.getId(),
+                        s.getItemDef().getName(),
+                        s.getItemDef().getItemType().name(),
+                        s.getItemDef().getItemGradeDef().getGrade().name(),
+                        s.getPrice(),
+                        s.getTradeType().name(),
+                        s.getSettledAt()
+                ))
+                .toList();
+
+        // 3. 페이지 정보 구성
+        SettlementHistoryResponse.PageInfo pageInfo = new SettlementHistoryResponse.PageInfo();
+        pageInfo.setCurrentPage(settlements.getNumber());
+        pageInfo.setPageSize(settlements.getSize());
+
+        // 4. Response DTO 생성
+        return new SettlementHistoryResponse(content, pageInfo);
 
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## 📑 기능 설명  
사용자가 지금까지 진행한 모든 거래 내역(판매/구매)을 조회할 수 있는 API입니다.  
페이지네이션을 통해 한 번에 일정 수의 거래 내역을 확인할 수 있으며, 거래 상태별 필터링이 가능합니다.  

## ✅ 작업할 내용  
- [x] GET /trades/me/history 엔드포인트 생성  
- [x] 페이지네이션 적용 (pageIndex, pageSize)  
- [x] 로그인 사용자 기준으로 거래 내역 조회 (판매 + 구매)  
- [x] 거래 상태/기간별 필터링 옵션 적용  
- [x] 응답 DTO(TradeHistoryResponse) 반환  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 사용자가 자신의 전체 거래 내역(판매/구매 모두)을 확인 가능  
- 거래 완료, 취소, 진행 중 상태를 한눈에 확인 가능  
- 페이지네이션으로 데이터 양 조절 가능  

## 📎 추가 정보  
- 기본 정렬: 거래 완료 시각(tradeAt) 기준 내림차순  
- 거래 상태 예시: OWNED, LISTED,  SOLD
- 필터 미적용 시 전체 거래 기록 조회  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 내 거래 정산 내역 조회 API 추가: 로그인 사용자가 자신의 정산 히스토리를 최신순으로 조회 가능
  - 페이지네이션 지원: 페이지 인덱스와 크기 지정, 목록과 페이지 정보 반환

- 리팩터링
  - DTO 생성자 및 불필요한 의존성 정리로 코드 가독성 개선

- 기타(Chores)
  - 데이터베이스 스키마 관리 방식을 자동 업데이트 모드로 전환하여 재시작 시 스키마를 보존 및 점진 반영

<!-- end of auto-generated comment: release notes by coderabbit.ai -->