### PR TITLE
Feature/23 get my sale items

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -70,8 +70,6 @@ public class AuctionController {
     }
 
 
-
-
     @GetMapping("/user/trades/me")
     public ResponseEntity<MySaleItemResponse> mySaleItems(
             @RequestBody MySaleItemRequest requestDto,

--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -73,13 +73,13 @@ public class AuctionController {
 
 
     @GetMapping("/user/trades/me")
-    public ResponseEntity<SettlementHistoryResponse> mySaleItems(
-            @RequestBody mySaleItemRequest requestDto,
+    public ResponseEntity<MySaleItemResponse> mySaleItems(
+            @RequestBody MySaleItemRequest requestDto,
             Authentication authentication) {
 
 
         Long userId = Long.valueOf(authentication.getName());
-        SettlementHistoryResponse result = auctionService.settlementHistory(userId, requestDto);
+        SettlementHistoryResponse result = auctionService.getMySaleItems(userId, requestDto);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -79,7 +79,7 @@ public class AuctionController {
 
 
         Long userId = Long.valueOf(authentication.getName());
-        SettlementHistoryResponse result = auctionService.getMySaleItems(userId, requestDto);
+        MySaleItemResponse result = auctionService.getMySaleItems(userId, requestDto);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -70,4 +70,17 @@ public class AuctionController {
     }
 
 
+
+
+    @GetMapping("/user/trades/me")
+    public ResponseEntity<SettlementHistoryResponse> mySaleItems(
+            @RequestBody mySaleItemRequest requestDto,
+            Authentication authentication) {
+
+
+        Long userId = Long.valueOf(authentication.getName());
+        SettlementHistoryResponse result = auctionService.settlementHistory(userId, requestDto);
+        return ResponseEntity.ok(result);
+    }
+
 }

--- a/src/main/java/com/scriptopia/demo/dto/auction/MySaleItemRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/MySaleItemRequest.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class mySaleItemRequest {
+public class MySaleItemRequest {
     private Long pageIndex;
     private Long pageSize;
 }

--- a/src/main/java/com/scriptopia/demo/dto/auction/MySaleItemResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/MySaleItemResponse.java
@@ -1,0 +1,26 @@
+package com.scriptopia.demo.dto.auction;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MySaleItemResponse {
+
+    private List<MySaleItemResponseItem> content;
+    private PageInfo pageInfo;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PageInfo {
+        private int currentPage;
+        private int pageSize;
+    }
+
+}

--- a/src/main/java/com/scriptopia/demo/dto/auction/MySaleItemResponseItem.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/MySaleItemResponseItem.java
@@ -1,0 +1,30 @@
+package com.scriptopia.demo.dto.auction;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MySaleItemResponseItem {
+    private Long auctionId;
+    private Long price;
+    private LocalDateTime createdAt;
+    private ItemDto item;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ItemDto {
+        private Long itemDefId;
+        private String name;
+        private String itemGrade;
+        private String itemType;
+        private String mainStat;
+        private String picSrc;
+    }
+}

--- a/src/main/java/com/scriptopia/demo/dto/auction/mySaleItemRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/auction/mySaleItemRequest.java
@@ -1,0 +1,13 @@
+package com.scriptopia.demo.dto.auction;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class mySaleItemRequest {
+    private Long pageIndex;
+    private Long pageSize;
+}

--- a/src/main/java/com/scriptopia/demo/repository/AuctionRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/AuctionRepository.java
@@ -60,5 +60,12 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
     );
 
 
+    Page<Auction> findByUserItem_User_IdAndUserItem_TradeStatus(
+            Long userId,
+            TradeStatus tradeStatus,
+            Pageable pageable
+    );
+
+
 
 }

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -302,4 +302,42 @@ public class AuctionService {
     }
 
 
+
+    public MySaleItemResponse getMySaleItems(Long userId, MySaleItemRequest requestDto) {
+        int page = requestDto.getPageIndex().intValue();
+        int size = requestDto.getPageSize().intValue();
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+
+        // 현재 판매중(LISTED)인 아이템만 조회
+        Page<Auction> auctions = auctionRepository.findByUserItem_User_IdAndUserItem_TradeStatus(
+                userId,
+                TradeStatus.LISTED,
+                pageable
+        );
+
+        // 응답 content 변환
+        List<MySaleItemResponseItem> content = auctions.stream()
+                .map(auction -> new MySaleItemResponseItem(
+                        auction.getId(),
+                        auction.getPrice(),
+                        auction.getCreatedAt(),
+                        new MySaleItemResponseItem.ItemDto(
+                                auction.getUserItem().getItemDef().getId(),
+                                auction.getUserItem().getItemDef().getName(),
+                                auction.getUserItem().getItemDef().getItemGradeDef().getGrade().name(),
+                                auction.getUserItem().getItemDef().getItemType().name(),
+                                auction.getUserItem().getItemDef().getMainStat().name(),
+                                auction.getUserItem().getItemDef().getPicSrc()
+                        )
+                )).toList();
+
+
+
+        // 페이지 정보
+        MySaleItemResponse.PageInfo pageInfo = new MySaleItemResponse.PageInfo(page, size);
+        return new MySaleItemResponse(content, pageInfo);
+    }
+
+
 }


### PR DESCRIPTION
## 📑 기능 설명
사용자가 자신이 경매장에 등록한 판매 아이템 목록을 조회할 수 있는 API입니다.
페이지네이션을 통해 한 번에 일정 수의 아이템을 확인할 수 있으며, 거래 상태별로 필터링도 가능합니다.

## ✅ 작업할 내용
- [x] GET /trades/me 엔드포인트 생성
- [x] 페이지네이션 적용 (pageIndex, pageSize)
- [x] 로그인 사용자 기준으로 등록 아이템 조회
- [x] 거래 상태 필터링 옵션 적용
- [x] 응답 DTO(TradeResponse) 반환
- [x] 성공/에러 응답 포맷 적용

## 🎈 기대 효과
- 사용자가 자신이 등록한 아이템 현황을 쉽게 확인 가능
- 거래 상태에 따라 판매 완료/판매 중 아이템 구분 가능
- 페이지네이션으로 데이터 양 조절 가능

## 📎 추가 정보
- 기본 정렬: 등록 시각 기준 내림차순
- 로그인 사용자 기준 조회
- 거래 상태 필터 미적용 시 전체 등록 아이템 조회

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 로그인한 사용자가 자신의 판매 중 아이템 목록을 조회할 수 있습니다.
  * 페이지네이션 지원: 페이지 번호와 페이지 크기 지정 가능.
  * 최신 등록순으로 정렬되어 제공됩니다.
  * 각 항목에 경매 ID, 가격, 등록일, 아이템 이름·등급·유형·주옵션·이미지 등이 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->