### PR TITLE
create cancelMySaleItem to controller

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -81,4 +81,17 @@ public class AuctionController {
         return ResponseEntity.ok(result);
     }
 
+
+
+    @DeleteMapping("/user/trades/{auctionId}")
+    public ResponseEntity<String> cancelMySaleItem(
+            @PathVariable String auctionId,
+            Authentication authentication) {
+
+        Long userId = Long.valueOf(authentication.getName());
+        String result = auctionService.cancelMySaleItem(userId, auctionId);
+        return ResponseEntity.ok(result);
+    }
+
+
 }

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -340,4 +340,35 @@ public class AuctionService {
     }
 
 
+
+    @Transactional
+    public String cancelMySaleItem(Long userId, String auctionIdStr) {
+        
+        //임시 uuid를 사용한다면 추후 변형하는 메소드로 변경바람
+        Long auctionId = Long.parseLong(auctionIdStr);
+
+        
+        // 1. 경매 정보 조회
+        Auction auction = auctionRepository.findById(auctionId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_AUCTION_NOT_FOUND));
+
+        UserItem userItem = auction.getUserItem();
+
+        // 2. 본인 검증
+        if (!userItem.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.E_403_ROLE_FORBIDDEN);
+        }
+
+
+        // 3. UserItem 상태 원복
+        userItem.setTradeStatus(TradeStatus.OWNED);
+        userItemRepository.save(userItem);
+
+
+        // 4. 경매장에서 삭제
+        auctionRepository.delete(auction);
+
+        return "판매 등록이 취소되었습니다.";
+    }
+
 }


### PR DESCRIPTION
## 📑 기능 설명  
사용자가 자신이 등록한 판매 중인 아이템을 경매장에서 취소할 수 있는 API입니다.  

## ✅ 작업할 내용  
- [x] DELETE /trades/{auctionId} 엔드포인트 생성  
- [x] 아이템 존재 여부 및 판매 상태 확인 (ON_SALE만 취소 가능)  
- [x] 로그인 사용자가 등록한 아이템인지 검증  
- [x] 거래 상태를 CANCELED로 업데이트 및 아이템 반환 처리  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 사용자가 실수로 올린 아이템을 자유롭게 취소 가능  
- 취소된 아이템은 다시 개인 인벤토리로 복원  
- 경매장에 잘못 노출된 아이템을 빠르게 제거 가능  

## 📎 추가 정보  
- 취소 가능한 상태: ON_SALE  
- 취소 완료 시 `tradeStatus = CANCELED` 로 변경  
- 거래 완료(SOLD_OUT)된 아이템은 취소 불가 → 409 Conflict 반환  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  - 판매 중인 아이템을 사용자가 직접 취소할 수 있는 삭제 엔드포인트(/user/trades/{auctionId}) 추가.
  - 로그인된 사용자 기준으로만 취소 가능하며, 본인 소유가 아닐 경우 403, 대상이 없으면 404 응답.
  - 취소 시 아이템 거래 상태가 원복되고 목록에서 제거되며, 확인 메시지를 응답으로 반환.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->