### PR TITLE
Feature/80 custum exception jwt

### DIFF
--- a/src/main/java/com/scriptopia/demo/config/SecurityConfig.java
+++ b/src/main/java/com/scriptopia/demo/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.scriptopia.demo.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scriptopia.demo.dto.exception.ErrorResponse;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,6 +19,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+
+import static com.scriptopia.demo.exception.ErrorCode.E_403;
 
 @Configuration
 @EnableWebSecurity
@@ -53,10 +57,14 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((req, res, e) -> {
-                            throw new CustomException(ErrorCode.E_401);
+                            res.setStatus(ErrorCode.E_401.getStatus().value());
+                            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            new ObjectMapper().writeValue(res.getOutputStream(),new ErrorResponse(ErrorCode.E_401));
                         })
                         .accessDeniedHandler((req, res, e) -> {
-                            throw new CustomException(ErrorCode.E_403);
+                            res.setStatus(ErrorCode.E_403.getStatus().value());
+                            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                            new ObjectMapper().writeValue(res.getOutputStream(),new ErrorResponse(ErrorCode.E_403));
                         })
                 );
         return http.build();

--- a/src/main/java/com/scriptopia/demo/config/SecurityConfig.java
+++ b/src/main/java/com/scriptopia/demo/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -37,7 +38,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(req -> {
                     var c = new CorsConfiguration();
                     c.setAllowedOrigins(List.of("http://localhost:3000")); // 현재는 로컬로 해놓고 나중에 바꿔야 댐

--- a/src/main/java/com/scriptopia/demo/config/SecurityConfig.java
+++ b/src/main/java/com/scriptopia/demo/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.scriptopia.demo.config;
 
+import com.scriptopia.demo.exception.CustomException;
+import com.scriptopia.demo.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -51,18 +53,10 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((req, res, e) -> {
-                            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                            res.getOutputStream().write(
-                                    "{\"code\":\"AUTH_401\",\"message\":\"Unauthorized\"}"
-                                            .getBytes(StandardCharsets.UTF_8));
+                            throw new CustomException(ErrorCode.E_401);
                         })
                         .accessDeniedHandler((req, res, e) -> {
-                            res.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                            res.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                            res.getOutputStream().write(
-                                    "{\"code\":\"AUTH_403\",\"message\":\"Forbidden\"}"
-                                            .getBytes(StandardCharsets.UTF_8));
+                            throw new CustomException(ErrorCode.E_403);
                         })
                 );
         return http.build();

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -37,6 +37,7 @@ public enum ErrorCode {
     E_401_REFRESH_EXPIRED("E401003","리프레쉬 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     E_401_CURRENT_PASSWORD_MISMATCH("E401004","현재 비밀번호가 올바르지 않습니다.",HttpStatus.UNAUTHORIZED),
     E_401_INVALID_SIGNATURE("E401001", "JWT 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    E_401_MALFORMED("E401002", "JWT 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
 
     //403 Forbidden
     E_403("E403000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     E_400_PASSWORD_WHITESPACE("E400010","비밀번호에 공백을 포함할 수 없습니다.",HttpStatus.BAD_REQUEST),
 
     //401 Unauthorized
+    E_401("401000", "인증되지 않은 요청입니다. (토큰 없음, 만료, 잘못됨)",HttpStatus.UNAUTHORIZED),
     E_401_INVALID_CREDENTIALS("E401001","이메일 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     E_401_CODE_MISMATCH("E401002","인증 코드가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     E_401_REFRESH_EXPIRED("E401003","리프레쉬 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     E_400_ITEM_NOT_TRADEABLE("E400015", "해당 아이템은 현재 경매장에 올릴 수 없습니다.", HttpStatus.BAD_REQUEST),
     E_400_ITEM_ALREADY_REGISTERED("E400016", "이미 경매장에 등록된 아이템입니다.", HttpStatus.BAD_REQUEST),
     E_400_INVALID_AMOUNT("E400017", "금액은 0보다 커야 합니다.", HttpStatus.BAD_REQUEST),
-
+    E_400_MISSING_JWT("E400018", "토큰 값이 비어있습니다.", HttpStatus.BAD_REQUEST),
 
     //401 Unauthorized
     E_401("401000", "인증되지 않은 요청입니다. (토큰 없음, 만료, 잘못됨)",HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     E_401_INVALID_SIGNATURE("E401001", "JWT 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
     E_401_MALFORMED("E401002", "JWT 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     E_401_EXPIRED_JWT("E401003", "JWT 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    E_401_UNSUPPORTED_JWT("E401004", "지원하지 않는 JWT 형식입니다.", HttpStatus.UNAUTHORIZED),
 
     //403 Forbidden
     E_403("E403000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     E_401_CODE_MISMATCH("E401002","인증 코드가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     E_401_REFRESH_EXPIRED("E401003","리프레쉬 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     E_401_CURRENT_PASSWORD_MISMATCH("E401004","현재 비밀번호가 올바르지 않습니다.",HttpStatus.UNAUTHORIZED),
+    E_401_INVALID_SIGNATURE("E401001", "JWT 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
 
     //403 Forbidden
     E_403("E403000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -36,10 +36,10 @@ public enum ErrorCode {
     E_401_CODE_MISMATCH("E401002","인증 코드가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
     E_401_REFRESH_EXPIRED("E401003","리프레쉬 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     E_401_CURRENT_PASSWORD_MISMATCH("E401004","현재 비밀번호가 올바르지 않습니다.",HttpStatus.UNAUTHORIZED),
-    E_401_INVALID_SIGNATURE("E401001", "JWT 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
-    E_401_MALFORMED("E401002", "JWT 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
-    E_401_EXPIRED_JWT("E401003", "JWT 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
-    E_401_UNSUPPORTED_JWT("E401004", "지원하지 않는 JWT 형식입니다.", HttpStatus.UNAUTHORIZED),
+    E_401_INVALID_SIGNATURE("E401005", "JWT 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
+    E_401_MALFORMED("E401006", "JWT 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    E_401_EXPIRED_JWT("E401007", "JWT 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    E_401_UNSUPPORTED_JWT("E401008", "지원하지 않는 JWT 형식입니다.", HttpStatus.UNAUTHORIZED),
 
     //403 Forbidden
     E_403("E403000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     E_400_SELF_PURCHASE("E400012", "자기 물건은 구매할 수 없습니다.", HttpStatus.BAD_REQUEST),
     E_400_INVALID_USER_ITEM_ID("E400013", "잘못된 아이템 ID 형식입니다.", HttpStatus.BAD_REQUEST),
     E_400_ITEM_NOT_OWNED("E400014", "해당 아이템은 사용자가 소유하지 않았습니다.", HttpStatus.BAD_REQUEST),
-    E_400_ITEM_NOT_TRADEABLE("E400015", "해당 아이템은 현재 경매장에 올릴 수 없습니다.", HttpStatus.BAD_REQUEST),
+    E_400_ITEM_NOT_TRADE_ABLE("E400015", "해당 아이템은 현재 경매장에 올릴 수 없습니다.", HttpStatus.BAD_REQUEST),
     E_400_ITEM_ALREADY_REGISTERED("E400016", "이미 경매장에 등록된 아이템입니다.", HttpStatus.BAD_REQUEST),
     E_400_INVALID_AMOUNT("E400017", "금액은 0보다 커야 합니다.", HttpStatus.BAD_REQUEST),
     E_400_MISSING_JWT("E400018", "토큰 값이 비어있습니다.", HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     E_401_CURRENT_PASSWORD_MISMATCH("E401004","현재 비밀번호가 올바르지 않습니다.",HttpStatus.UNAUTHORIZED),
     E_401_INVALID_SIGNATURE("E401001", "JWT 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED),
     E_401_MALFORMED("E401002", "JWT 형식이 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+    E_401_EXPIRED_JWT("E401003", "JWT 토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
 
     //403 Forbidden
     E_403("E403000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -30,8 +30,8 @@ public enum ErrorCode {
     E_401_CURRENT_PASSWORD_MISMATCH("E401004","현재 비밀번호가 올바르지 않습니다.",HttpStatus.UNAUTHORIZED),
 
     //403 Forbidden
-    E_403_ROLE_FORBIDDEN("E403001", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    E_403_DEVICE_MISMATCH("E403002", "요청 디바이스와 토큰의 디바이스가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
+    E_403("E403000", "접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    E_403_DEVICE_MISMATCH("E403001", "요청 디바이스와 토큰의 디바이스가 일치하지 않습니다.", HttpStatus.FORBIDDEN),
 
     //404 Not Found
     E_404_REFRESH_NOT_FOUND("E404001", "유효한 리프레시 세션을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -51,7 +51,7 @@ public class AuctionService {
 
         // 거래 상태 확인
         if (userItem.getTradeStatus() != TradeStatus.OWNED) {
-            throw new CustomException(ErrorCode.E_400_ITEM_NOT_TRADEABLE);
+            throw new CustomException(ErrorCode.E_400_ITEM_NOT_TRADE_ABLE);
         }
 
         // 이미 경매장에 등록되어 있는지 확인

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -234,7 +234,7 @@ public class AuctionService {
 
         // 정산 대상 유저 확인
         if (!settlement.getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.E_403_ROLE_FORBIDDEN);
+            throw new CustomException(ErrorCode.E_403);
         }
 
         // 이미 정산 완료 여부 확인
@@ -356,7 +356,7 @@ public class AuctionService {
 
         // 2. 본인 검증
         if (!userItem.getUser().getId().equals(userId)) {
-            throw new CustomException(ErrorCode.E_403_ROLE_FORBIDDEN);
+            throw new CustomException(ErrorCode.E_403);
         }
 
 


### PR DESCRIPTION
## 🚀 관련 이슈

Close #80 

## 📑 PR 설명
JWT 인증 관련 예외를 처리한다.
## ✏️ 작업 내용
1. filterChain에서 401,403에러 잡을 시 예외 처리
2. JWT 토큰 관련 예외 처리
## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 빌드 통과 확인
- [x] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증/인가 실패 시 표준화된 JSON 오류 응답을 제공합니다.
  - JWT 오류 유형별(만료, 형식 오류, 지원 불가, 서명 무효, 누락)로 세분화된 메시지와 상태코드를 반환합니다.
- 버그 수정
  - 잘못된/만료된/미지원 토큰 처리 시 올바른 HTTP 상태 코드와 일관된 오류 본문을 반환하도록 개선했습니다.
- 리팩터링
  - 오류 코드 체계를 정비하고 명칭을 일관되게 변경해 응답 일관성과 가독성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->