### PR TITLE
[Feature] 공유게임 추천 기능

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameFavoriteController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameFavoriteController.java
@@ -1,0 +1,24 @@
+package com.scriptopia.demo.controller;
+
+import com.scriptopia.demo.service.SharedGameFavoriteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users/games")
+@RequiredArgsConstructor
+public class SharedGameFavoriteController {
+    private final SharedGameFavoriteService sharedGameFavoriteService;
+
+    @PostMapping("/shared/{sharedGameId}/like")
+    public ResponseEntity<?> likeSharedGame(@PathVariable Long sharedGameId, Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return sharedGameFavoriteService.saveFavorite(userId, sharedGameId);
+    }
+}

--- a/src/main/java/com/scriptopia/demo/domain/GameTag.java
+++ b/src/main/java/com/scriptopia/demo/domain/GameTag.java
@@ -15,5 +15,8 @@ public class GameTag {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    private SharedGame sharedGame;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     private TagDef tagDef;
 }

--- a/src/main/java/com/scriptopia/demo/dto/sharedgamefavorite/SharedGameFavoriteResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgamefavorite/SharedGameFavoriteResponse.java
@@ -1,0 +1,15 @@
+package com.scriptopia.demo.dto.sharedgamefavorite;
+
+import lombok.Data;
+
+@Data
+public class SharedGameFavoriteResponse {
+    private Long sharedGameId;
+    private String thumbnailUrl;
+    private boolean isLiked;
+    private Long likeCount;
+    private Long totalPlayCount;
+    private String title;
+    private String[] tags;
+    private Float topScore;
+}

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     //404 Not Found
     E_404_REFRESH_NOT_FOUND("E404001", "유효한 리프레시 세션을 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
     E_404_USER_NOT_FOUND("E404002","사용자를 찾을 수 없습니다.",HttpStatus.NOT_FOUND),
+    E_404_SHARED_GAME_NOT_FOUND("E404005", "공유된 게임을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     //409 Conflict
     E_409_EMAIL_TAKEN("E409001", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT),

--- a/src/main/java/com/scriptopia/demo/repository/GameTagRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/GameTagRepository.java
@@ -2,6 +2,14 @@ package com.scriptopia.demo.repository;
 
 import com.scriptopia.demo.domain.GameTag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface GameTagRepository extends JpaRepository<GameTag, Long> {
+    @Query("select gt.tagDef.tagName " +
+            "from GameTag gt " +
+            "where gt.sharedGame.id = :sharedGameId")
+    List<String> findTagNamesBySharedGameId(@Param("sharedGameId") Long sharedGameId);
 }

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameFavoriteRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameFavoriteRepository.java
@@ -4,5 +4,11 @@ import com.scriptopia.demo.domain.SharedGame;
 import com.scriptopia.demo.domain.SharedGameFavorite;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SharedGameFavoriteRepository extends JpaRepository<SharedGameFavorite, Long> {
+    Optional<SharedGameFavorite> findByUserIdAndSharedGameId(Long userId, Long sharedGameId);
+    boolean existsByUserIdAndSharedGameId(Long userId, Long sharedGameId);
+    long countBySharedGameId(Long sharedGameId);
+    void deleteByUserIdAndSharedGameId(Long userId, Long sharedGameId);
 }

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
@@ -3,6 +3,12 @@ package com.scriptopia.demo.repository;
 import com.scriptopia.demo.domain.SharedGame;
 import com.scriptopia.demo.domain.SharedGameScore;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SharedGameScoreRepository extends JpaRepository<SharedGameScore, Long> {
+    @Query("Select count(s) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
+    long countBySharedGameId(Long sharedGameId);
+
+    @Query("select max(s.score) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
+    Long maxScoreBySharedGameId(Long sharedGameId);
 }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameFavoriteService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameFavoriteService.java
@@ -1,0 +1,64 @@
+package com.scriptopia.demo.service;
+
+import com.scriptopia.demo.domain.SharedGameFavorite;
+import com.scriptopia.demo.dto.sharedgamefavorite.SharedGameFavoriteResponse;
+import com.scriptopia.demo.exception.CustomException;
+import com.scriptopia.demo.exception.ErrorCode;
+import com.scriptopia.demo.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class SharedGameFavoriteService {
+    private final SharedGameFavoriteRepository sharedGameFavoriteRepository;
+    private final SharedGameRepository sharedGameRepository;
+    private final GameTagRepository gameTagRepository;
+    private final UserRepository userRepository;
+    private final SharedGameScoreRepository sharedGameScoreRepository;
+
+    @Transactional
+    public ResponseEntity<?> saveFavorite(Long userId, Long sharedGameId) {
+        var user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
+        var game = sharedGameRepository.findById(sharedGameId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_SHARED_GAME_NOT_FOUND));
+
+        // 토글 처리
+        var existing = sharedGameFavoriteRepository.findByUserIdAndSharedGameId(userId, sharedGameId);
+        boolean liked;
+        if (existing.isPresent()) {
+            sharedGameFavoriteRepository.delete(existing.get());
+            liked = false;
+        } else {
+            var fav = new SharedGameFavorite();
+            fav.setUser(user);
+            fav.setSharedGame(game);
+            sharedGameFavoriteRepository.save(fav);
+            liked = true;
+        }
+
+        long likeCount = sharedGameFavoriteRepository.countBySharedGameId(sharedGameId);
+        long playCount = sharedGameScoreRepository.countBySharedGameId(sharedGameId);
+        Long maxScore  = sharedGameScoreRepository.maxScoreBySharedGameId(sharedGameId);
+
+        // 태그 이름들
+        var tagNames = gameTagRepository.findTagNamesBySharedGameId(sharedGameId);
+
+        // DTO 구성
+        var dto = new SharedGameFavoriteResponse();
+        dto.setSharedGameId(sharedGameId);
+        dto.setThumbnailUrl(game.getThumbnailUrl());
+        dto.setLiked(liked);
+        dto.setLikeCount(likeCount);
+        dto.setTotalPlayCount(playCount);
+        dto.setTitle(game.getTitle());
+        dto.setTags(tagNames.isEmpty() ? null : tagNames.toArray(new String[0]));
+        dto.setTopScore(maxScore == null ? null : maxScore.floatValue());
+
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## 🚀 관련 이슈

Close #82 

## 📑 PR 설명
공유된 게임을 추천버튼 누르는 기능 추가

## ✏️ 작업 내용
공유된 게임의 내용을 출력하는 부분에서 Tag 부분이 빠져서 repository 기능 추가, 게임 스코어 부분이 빠져서 GameScore Service, Repository 기능 추가, 공유된 게임 dto, controller, service 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 공유 게임 좋아요 토글 기능 추가: 로그인 사용자가 좋아요/해제를 수행할 수 있습니다.
  - 응답 메타정보 제공: 좋아요 여부, 좋아요 수, 총 플레이 수, 태그 목록, 최고 점수, 썸네일, 제목을 반환합니다.
  - 공유 게임별 태그 조회 지원으로 태그 표시가 가능해졌습니다.
  - 공유된 게임을 찾을 수 없는 경우 404 오류 코드와 명확한 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->