### PR TITLE
Feature/87 create pia item

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -11,7 +11,8 @@ import org.springframework.web.bind.annotation.*;
 public class PiaShopController {
     private final PiaShopService piaShopService;
 
-    @PostMapping("/admin/items/pia")
+    // admin → public 으로 테스트용 변경했음 나중에 수정 바람
+    @PostMapping("/public/items/pia")
     public ResponseEntity<String> createPiaItem(@RequestBody PiaItemRequest request) {
 
 

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -1,0 +1,17 @@
+package com.scriptopia.demo.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PiaShopController {
+
+
+
+
+    @PostMapping("/admin/items/pia")
+
+}

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -1,17 +1,22 @@
 package com.scriptopia.demo.controller;
 
-
+import com.scriptopia.demo.dto.piashop.PiaItemRequest;
+import com.scriptopia.demo.repository.PiaItemRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/admin/items")
 public class PiaShopController {
 
 
+    @PostMapping("/pia")
+    public ResponseEntity<String> createPiaItem(@RequestBody PiaItemRequest request) {
 
 
-    @PostMapping("/admin/items/pia")
 
+        return ResponseEntity.ok("PIA 아이템이 등록되었습니다.");
+    }
 }

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -1,21 +1,21 @@
 package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
+import com.scriptopia.demo.service.PiaShopService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/items")
 public class PiaShopController {
-    private final P
+    private final PiaShopService piaShopService;
 
-    @PostMapping("/pia")
+    @PostMapping("/admin/items/pia")
     public ResponseEntity<String> createPiaItem(@RequestBody PiaItemRequest request) {
 
 
-
+        piaShopService.createPiaItem(request);
         return ResponseEntity.ok("PIA 아이템이 등록되었습니다.");
     }
 }

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -1,7 +1,6 @@
 package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
-import com.scriptopia.demo.repository.PiaItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -10,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/admin/items")
 public class PiaShopController {
-
+    private final P
 
     @PostMapping("/pia")
     public ResponseEntity<String> createPiaItem(@RequestBody PiaItemRequest request) {

--- a/src/main/java/com/scriptopia/demo/dto/piashop/PiaItemRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/piashop/PiaItemRequest.java
@@ -1,0 +1,15 @@
+package com.scriptopia.demo.dto.piashop;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PiaItemRequest {
+    private String name;
+    private Long price;
+    private String description;
+}

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -29,6 +29,9 @@ public enum ErrorCode {
     E_400_ITEM_ALREADY_REGISTERED("E400016", "이미 경매장에 등록된 아이템입니다.", HttpStatus.BAD_REQUEST),
     E_400_INVALID_AMOUNT("E400017", "금액은 0보다 커야 합니다.", HttpStatus.BAD_REQUEST),
     E_400_MISSING_JWT("E400018", "토큰 값이 비어있습니다.", HttpStatus.BAD_REQUEST),
+    E_400_PIA_ITEM_DUPLICATE("E400100", "이미 존재하는 PIA 아이템 이름입니다.", HttpStatus.BAD_REQUEST),
+    E_400_INVALID_REQUEST("E400101", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+
 
     //401 Unauthorized
     E_401("401000", "인증되지 않은 요청입니다. (토큰 없음, 만료, 잘못됨)",HttpStatus.UNAUTHORIZED),

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
     E_400_INVALID_AMOUNT("E400017", "금액은 0보다 커야 합니다.", HttpStatus.BAD_REQUEST),
     E_400_MISSING_JWT("E400018", "토큰 값이 비어있습니다.", HttpStatus.BAD_REQUEST),
     E_400_PIA_ITEM_DUPLICATE("E400100", "이미 존재하는 PIA 아이템 이름입니다.", HttpStatus.BAD_REQUEST),
-    E_400_INVALID_REQUEST("E400101", "잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    E_400_INVALID_REQUEST("E400101", "이름이나, 금액이 비어있습니다.", HttpStatus.BAD_REQUEST),
 
 
     //401 Unauthorized

--- a/src/main/java/com/scriptopia/demo/repository/PiaItemRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/PiaItemRepository.java
@@ -5,4 +5,5 @@ import com.scriptopia.demo.domain.PiaItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PiaItemRepository extends JpaRepository<PiaItem, Long> {
+    boolean existsByName(String name);  // 이름으로 중복 체크
 }

--- a/src/main/java/com/scriptopia/demo/repository/PiaShopRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/PiaShopRepository.java
@@ -1,0 +1,9 @@
+package com.scriptopia.demo.repository;
+
+import com.scriptopia.demo.domain.PiaItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PiaShopRepository extends JpaRepository<PiaItem, Long> {
+
+}
+

--- a/src/main/java/com/scriptopia/demo/repository/PiaShopRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/PiaShopRepository.java
@@ -1,9 +1,0 @@
-package com.scriptopia.demo.repository;
-
-import com.scriptopia.demo.domain.PiaItem;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PiaShopRepository extends JpaRepository<PiaItem, Long> {
-
-}
-

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -1,0 +1,14 @@
+package com.scriptopia.demo.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PiaShopService {
+
+
+}

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -1,6 +1,7 @@
 package com.scriptopia.demo.service;
 
 
+import com.scriptopia.demo.dto.piashop.PiaItemRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,5 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PiaShopService {
 
+
+    @Transactional
+    public String createPiaItem(PiaItemRequest request){
+
+
+
+    }
 
 }

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -21,16 +21,18 @@ public class PiaShopService {
 
         // 1. 필수 값 확인
         if(request.getName() == null || request.getName().isBlank()) {
-            throw new CustomException(ErrorCode.E_400_MISSING_NICKNAME); // 이름 필수 체크
+            throw new CustomException(ErrorCode.E_400_INVALID_REQUEST); // 이름 필수 체크
         }
+
         if(request.getPrice() == null || request.getPrice() <= 0) {
-            throw new CustomException(ErrorCode.E_400_INVALID_AMOUNT);
+            throw new CustomException(ErrorCode.E_400_INVALID_REQUEST); // 금액 유효성 체크
         }
 
         // 2. 중복 이름 체크
         if(piaItemRepository.existsByName(request.getName())) {
-            throw new CustomException(ErrorCode.E_409_ALREADY_CONFIRMED); // 적절한 오류 코드 선택
+            throw new CustomException(ErrorCode.E_400_PIA_ITEM_DUPLICATE); // 중복 이름 오류
         }
+
 
         // 3. PiaItem 생성
         PiaItem piaItem = new PiaItem();

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -1,7 +1,10 @@
 package com.scriptopia.demo.service;
 
-
+import com.scriptopia.demo.domain.PiaItem;
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
+import com.scriptopia.demo.exception.CustomException;
+import com.scriptopia.demo.exception.ErrorCode;
+import com.scriptopia.demo.repository.PiaItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,12 +14,32 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PiaShopService {
 
+    private final PiaItemRepository piaItemRepository;
 
     @Transactional
-    public String createPiaItem(PiaItemRequest request){
+    public String createPiaItem(PiaItemRequest request) {
 
+        // 1. 필수 값 확인
+        if(request.getName() == null || request.getName().isBlank()) {
+            throw new CustomException(ErrorCode.E_400_MISSING_NICKNAME); // 이름 필수 체크
+        }
+        if(request.getPrice() == null || request.getPrice() <= 0) {
+            throw new CustomException(ErrorCode.E_400_INVALID_AMOUNT);
+        }
 
+        // 2. 중복 이름 체크
+        if(piaItemRepository.existsByName(request.getName())) {
+            throw new CustomException(ErrorCode.E_409_ALREADY_CONFIRMED); // 적절한 오류 코드 선택
+        }
 
+        // 3. PiaItem 생성
+        PiaItem piaItem = new PiaItem();
+        piaItem.setName(request.getName());
+        piaItem.setPrice(String.valueOf(request.getPrice()));
+        piaItem.setDescription(request.getDescription());
+
+        piaItemRepository.save(piaItem);
+
+        return "PIA 아이템이 성공적으로 생성되었습니다.";
     }
-
 }


### PR DESCRIPTION
## 📑 기능 설명  
관리자가 새로운 상품(Pia)을 생성할 수 있는 API입니다.  
생성된 상품은 결제/구매 시스템에서 사용 가능하며, 상품명, 가격, 설명 등 기본 정보를 입력합니다.  

## ✅ 작업할 내용  
- [x] POST /admin/items/pia 엔드포인트 생성  
- [x] 요청 바디 유효성 검증 (name, price, description 등)  
- [x] 상품 이름 중복 체크  
- [x] DB에 상품 정보 저장  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 관리자가 새로운 상품을 쉽게 등록 가능  
- 상품 정보가 결제/구매 시스템과 연동되어 바로 활용 가능  
- 중복 상품 등록 방지로 데이터 무결성 유지  

## 📎 추가 정보  
- 엔드포인트: `POST /admin/items/pia`  
- 요청 바디 예시:
```json
{
  "name": "500Pia 충전권",
  "description": "게임 내 사용 가능한 500Pia 충전권",
  "price": 5000
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * PIA 아이템 생성 기능 추가: 공개 경로에서 신규 아이템을 등록할 수 있습니다.
  * 유효성 검증 강화: 이름과 금액 누락/유효하지 않은 값에 대한 즉시 오류 응답을 제공합니다.
  * 중복 방지: 이미 존재하는 아이템 이름 등록 시 명확한 오류 메시지를 반환합니다.
  * 응답 개선: 성공 시 사용자 친화적 안내 메시지를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->