### PR TITLE
Feature/88 update pia item

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -1,6 +1,7 @@
 package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
+import com.scriptopia.demo.dto.piashop.PiaItemUpdateRequest;
 import com.scriptopia.demo.service.PiaShopService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,5 +19,15 @@ public class PiaShopController {
         return ResponseEntity.ok("PIA 아이템이 등록되었습니다.");
     }
 
+
+    @PutMapping("/public/items/pia/{itemId}")
+    public ResponseEntity<String> updatePiaItem(
+            @PathVariable String itemId,
+            @RequestBody PiaItemUpdateRequest requestDto) {
+
+
+        String result = piaShopService.updatePiaItem(requestDto);
+        return ResponseEntity.ok(result);
+    }
 
 }

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -26,7 +26,7 @@ public class PiaShopController {
             @RequestBody PiaItemUpdateRequest requestDto) {
 
 
-        String result = piaShopService.updatePiaItem(requestDto);
+        String result = piaShopService.updatePiaItem(itemId, requestDto);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -14,9 +14,9 @@ public class PiaShopController {
     // admin → public 으로 테스트용 변경했음 나중에 수정 바람
     @PostMapping("/public/items/pia")
     public ResponseEntity<String> createPiaItem(@RequestBody PiaItemRequest request) {
-
-
         piaShopService.createPiaItem(request);
         return ResponseEntity.ok("PIA 아이템이 등록되었습니다.");
     }
+
+
 }

--- a/src/main/java/com/scriptopia/demo/domain/PiaItem.java
+++ b/src/main/java/com/scriptopia/demo/domain/PiaItem.java
@@ -15,6 +15,6 @@ public class PiaItem {
     private Long id;
 
     private String name;
-    private String price;
+    private Long price;
     private String description;
 }

--- a/src/main/java/com/scriptopia/demo/dto/piashop/PiaItemUpdateRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/piashop/PiaItemUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.scriptopia.demo.dto.piashop;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PiaItemUpdateRequest {
+    private String name;      // 이름
+    private Long price;       // 가격
+    private String description; // 설명
+}

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -29,8 +29,9 @@ public enum ErrorCode {
     E_400_ITEM_ALREADY_REGISTERED("E400016", "이미 경매장에 등록된 아이템입니다.", HttpStatus.BAD_REQUEST),
     E_400_INVALID_AMOUNT("E400017", "금액은 0보다 커야 합니다.", HttpStatus.BAD_REQUEST),
     E_400_MISSING_JWT("E400018", "토큰 값이 비어있습니다.", HttpStatus.BAD_REQUEST),
-    E_400_PIA_ITEM_DUPLICATE("E400100", "이미 존재하는 PIA 아이템 이름입니다.", HttpStatus.BAD_REQUEST),
-    E_400_INVALID_REQUEST("E400101", "이름이나, 금액이 비어있습니다.", HttpStatus.BAD_REQUEST),
+    E_400_PIA_ITEM_DUPLICATE("E400019", "이미 존재하는 PIA 아이템 이름입니다.", HttpStatus.BAD_REQUEST),
+    E_400_INVALID_REQUEST("E400020", "이름이나, 금액이 비어있습니다.", HttpStatus.BAD_REQUEST),
+
 
 
     //401 Unauthorized

--- a/src/main/java/com/scriptopia/demo/repository/PiaItemRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/PiaItemRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PiaItemRepository extends JpaRepository<PiaItem, Long> {
     boolean existsByName(String name);  // 이름으로 중복 체크
+
+    boolean existsByNameAndIdNot(String name, Long id);
 }

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -7,6 +7,7 @@ import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.PiaItemRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +34,6 @@ public class PiaShopService {
         if(piaItemRepository.existsByName(request.getName())) {
             throw new CustomException(ErrorCode.E_400_PIA_ITEM_DUPLICATE); // 중복 이름 오류
         }
-
 
         // 3. PiaItem 생성
         PiaItem piaItem = new PiaItem();

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -44,4 +44,7 @@ public class PiaShopService {
 
         return "PIA 아이템이 성공적으로 생성되었습니다.";
     }
+
+
+
 }

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -2,6 +2,7 @@ package com.scriptopia.demo.service;
 
 import com.scriptopia.demo.domain.PiaItem;
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
+import com.scriptopia.demo.dto.piashop.PiaItemUpdateRequest;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.PiaItemRepository;
@@ -37,7 +38,7 @@ public class PiaShopService {
         // 3. PiaItem 생성
         PiaItem piaItem = new PiaItem();
         piaItem.setName(request.getName());
-        piaItem.setPrice(String.valueOf(request.getPrice()));
+        piaItem.setPrice(request.getPrice());
         piaItem.setDescription(request.getDescription());
 
         piaItemRepository.save(piaItem);
@@ -46,5 +47,38 @@ public class PiaShopService {
     }
 
 
+    @Transactional
+    public String updatePiaItem(String itemsIdStr, PiaItemUpdateRequest request) {
+
+        // uuid 사용 시 변경 (임시임)
+        Long itemsId = Long.valueOf(itemsIdStr);
+
+
+        // 1. 필수 값 체크
+        if (request.getName() == null || request.getName().isBlank()) {
+            throw new CustomException(ErrorCode.E_400_MISSING_NICKNAME); // 이름 필수
+        }
+        if (request.getPrice() == null || request.getPrice() <= 0) {
+            throw new CustomException(ErrorCode.E_400_INVALID_AMOUNT); // 가격 필수
+        }
+
+        // 2. 아이템 존재 확인
+        PiaItem piaItem = piaItemRepository.findById(itemsId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_AUCTION_NOT_FOUND)); // 존재하지 않는 아이템
+
+        // 3. 이름 중복 체크 (자기 자신 제외)
+        if (piaItemRepository.existsByNameAndIdNot(request.getName(),itemsId)){
+            throw new CustomException(ErrorCode.E_409_ALREADY_CONFIRMED); // 이름 중복
+        }
+
+        // 4. 정보 업데이트
+        piaItem.setName(request.getName());
+        piaItem.setPrice(request.getPrice());
+        piaItem.setDescription(request.getDescription());
+
+        piaItemRepository.save(piaItem);
+
+        return "PIA 아이템이 성공적으로 수정되었습니다.";
+    }
 
 }


### PR DESCRIPTION
## 📑 기능 설명  
관리자가 기존 상품(Pia)의 정보를 수정할 수 있는 API입니다.  
상품명, 가격, 설명 등 필요한 정보를 업데이트하여 결제/구매 시스템에서 최신 정보로 활용할 수 있습니다.  

## ✅ 작업할 내용  
- [x] PUT /admin/items/pia/{itemId} 엔드포인트 생성  
- [x] path 변수로 itemId 전달받기  
- [x] 요청 바디 유효성 검증 (name, price, description 등)  
- [x] 상품 존재 여부 확인  
- [x] DB에 상품 정보 업데이트  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 관리자가 기존 상품 정보를 안전하게 수정 가능  
- 수정된 정보가 즉시 결제/구매 시스템에 반영  
- 잘못된 상품 정보로 인한 사용자 혼동 방지  

## 📎 추가 정보  
- 엔드포인트: `PUT /admin/items/pia/{itemId}`  
- 요청 바디 예시:
```json
{
  "name": "1000Pia 충전권",
  "description": "게임 내 사용 가능한 1000Pia 충전권",
  "price": 10000
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - PIA 아이템 수정용 PUT 엔드포인트 추가: 이름, 가격, 설명 업데이트 지원. 존재 여부 확인 및 중복 이름 검증 포함. 성공 시 안내 메시지 반환.
- Refactor
  - 가격을 문자열에서 숫자형으로 전환하여 입력·저장 일관성 및 계산 신뢰성 향상. 생성/수정 흐름에서 숫자 가격 사용.
- Chores
  - 일부 400 오류 코드 번호 재정렬(메시지와 동작은 동일).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->