### PR TITLE
Feature/89 get pia items

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -1,11 +1,14 @@
 package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
+import com.scriptopia.demo.dto.piashop.PiaItemResponse;
 import com.scriptopia.demo.dto.piashop.PiaItemUpdateRequest;
 import com.scriptopia.demo.service.PiaShopService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +23,7 @@ public class PiaShopController {
     }
 
 
+    // admin → public 으로 테스트용 변경했음 나중에 수정 바람
     @PutMapping("/public/items/pia/{itemId}")
     public ResponseEntity<String> updatePiaItem(
             @PathVariable String itemId,
@@ -28,6 +32,13 @@ public class PiaShopController {
 
         String result = piaShopService.updatePiaItem(itemId, requestDto);
         return ResponseEntity.ok(result);
+    }
+
+
+
+    @GetMapping("/public/shops/pia/items")
+    public ResponseEntity<List<PiaItemResponse>> getPiaItems() {
+        return ResponseEntity.ok(piaShopService.getPiaItems());
     }
 
 }

--- a/src/main/java/com/scriptopia/demo/dto/piashop/PiaItemResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/piashop/PiaItemResponse.java
@@ -1,0 +1,27 @@
+package com.scriptopia.demo.dto.piashop;
+
+import com.scriptopia.demo.domain.PiaItem;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PiaItemResponse {
+    private Long id;
+    private String name;
+    private Long price;
+    private String description;
+
+
+    public static PiaItemResponse fromEntity(PiaItem item) {
+        return new PiaItemResponse(
+                item.getId(),
+                item.getName(),
+                item.getPrice(),
+                item.getDescription()
+        );
+    }
+
+}

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -2,6 +2,7 @@ package com.scriptopia.demo.service;
 
 import com.scriptopia.demo.domain.PiaItem;
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
+import com.scriptopia.demo.dto.piashop.PiaItemResponse;
 import com.scriptopia.demo.dto.piashop.PiaItemUpdateRequest;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
@@ -10,6 +11,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -80,5 +84,14 @@ public class PiaShopService {
 
         return "PIA 아이템이 성공적으로 수정되었습니다.";
     }
+
+
+
+    public List<PiaItemResponse> getPiaItems() {
+        return piaItemRepository.findAll().stream()
+                .map(PiaItemResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
 
 }


### PR DESCRIPTION
## 📑 기능 설명  
사용자가 Shop에서 판매 중인 Pia 상품 목록을 조회할 수 있는 API입니다.  
페가격, 이름 등 기본 정보가 제공됩니다.  

## ✅ 작업할 내용  
- [x] GET /shops/pia/items 엔드포인트 생성    
- [x] 응답 DTO(ShopPiaItemResponse) 반환  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 사용자가 판매 중인 상품 목록을 쉽게 확인 가능  
- 결제/구매 시 최신 상품 정보를 기반으로 선택 가능  

## 📎 추가 정보  
- 엔드포인트: `GET /shops/pia/items`  
- 기본 정렬: 상품명 또는 등록 시각 기준  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Pia 상점 아이템을 한 번에 조회할 수 있는 공개 API가 추가되었습니다. 클라이언트는 전체 목록을 받아 카탈로그/목록 화면을 쉽게 구성하고 가격·설명 등의 정보를 사용자에게 표시할 수 있습니다. 표준 HTTP 응답으로 단순 리스트를 반환하며, 기존 아이템 생성·수정 흐름은 변경 없이 그대로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->