### PR TITLE
Feature/90 purchase pia item

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -44,7 +44,7 @@ public class PiaShopController {
     }
 
 
-    @PostMapping("/user/shops/pia/orders")
+    @PostMapping("/user/shops/pia/item/purchase")
     public ResponseEntity<String> purchasePiaItem(
             @RequestBody PurchasePiaItemRequest requestDto,
             Authentication authentication) {

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -41,4 +41,7 @@ public class PiaShopController {
         return ResponseEntity.ok(piaShopService.getPiaItems());
     }
 
+
+
+
 }

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -3,9 +3,11 @@ package com.scriptopia.demo.controller;
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
 import com.scriptopia.demo.dto.piashop.PiaItemResponse;
 import com.scriptopia.demo.dto.piashop.PiaItemUpdateRequest;
+import com.scriptopia.demo.dto.piashop.PurchasePiaItemRequest;
 import com.scriptopia.demo.service.PiaShopService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -36,12 +38,21 @@ public class PiaShopController {
 
 
 
-    @GetMapping("/public/shops/pia/items")
+    @GetMapping("/user/shops/pia/items")
     public ResponseEntity<List<PiaItemResponse>> getPiaItems() {
         return ResponseEntity.ok(piaShopService.getPiaItems());
     }
 
 
+    @PostMapping("/user/shops/pia/orders")
+    public ResponseEntity<String> purchasePiaItem(
+            @RequestBody PurchasePiaItemRequest requestDto,
+            Authentication authentication) {
+
+        Long userId = Long.valueOf(authentication.getName());
+        piaShopService.purchasePiaItem(userId, requestDto);
+        return ResponseEntity.ok("PIA 아이템을 구매했습니다.");
+    }
 
 
 }

--- a/src/main/java/com/scriptopia/demo/domain/PiaItemPurchaseLog.java
+++ b/src/main/java/com/scriptopia/demo/domain/PiaItemPurchaseLog.java
@@ -23,4 +23,10 @@ public class PiaItemPurchaseLog {
 
     private LocalDateTime purchaseDate;
     private Long price;
+
+    @PrePersist
+    public void prePersist() {
+        this.purchaseDate = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/scriptopia/demo/domain/PiaItemPurchaseLog.java
+++ b/src/main/java/com/scriptopia/demo/domain/PiaItemPurchaseLog.java
@@ -1,0 +1,26 @@
+package com.scriptopia.demo.domain;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+public class PiaItemPurchaseLog {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private PiaItem piaItem;
+
+    private LocalDateTime purchaseDate;
+    private Long price;
+}

--- a/src/main/java/com/scriptopia/demo/dto/piashop/PurchasePiaItemRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/piashop/PurchasePiaItemRequest.java
@@ -1,0 +1,14 @@
+package com.scriptopia.demo.dto.piashop;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PurchasePiaItemRequest {
+    private String itemId;
+    private int quantity;
+}

--- a/src/main/java/com/scriptopia/demo/repository/PurchaseLogRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/PurchaseLogRepository.java
@@ -1,0 +1,7 @@
+package com.scriptopia.demo.repository;
+
+import com.scriptopia.demo.domain.PiaItemPurchaseLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PurchaseLogRepository extends JpaRepository<PiaItemPurchaseLog, Long> {
+}

--- a/src/main/java/com/scriptopia/demo/repository/UserPiaItemRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/UserPiaItemRepository.java
@@ -1,8 +1,12 @@
 package com.scriptopia.demo.repository;
 
+import com.scriptopia.demo.domain.PiaItem;
 import com.scriptopia.demo.domain.User;
 import com.scriptopia.demo.domain.UserPiaItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPiaItemRepository extends JpaRepository<UserPiaItem, Long> {
+    Optional<UserPiaItem> findByUserAndPiaItem(User user, PiaItem piaItem);
 }

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -1,12 +1,18 @@
 package com.scriptopia.demo.service;
 
 import com.scriptopia.demo.domain.PiaItem;
+import com.scriptopia.demo.domain.PiaItemPurchaseLog;
+import com.scriptopia.demo.domain.User;
+import com.scriptopia.demo.domain.UserPiaItem;
 import com.scriptopia.demo.dto.piashop.PiaItemRequest;
 import com.scriptopia.demo.dto.piashop.PiaItemResponse;
 import com.scriptopia.demo.dto.piashop.PiaItemUpdateRequest;
+import com.scriptopia.demo.dto.piashop.PurchasePiaItemRequest;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.PiaItemRepository;
+import com.scriptopia.demo.repository.UserPiaItemRepository;
+import com.scriptopia.demo.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -21,6 +27,8 @@ import java.util.stream.Collectors;
 public class PiaShopService {
 
     private final PiaItemRepository piaItemRepository;
+    private final UserRepository userRepository;
+    private final UserPiaItemRepository userPiaItemRepository;
 
     @Transactional
     public String createPiaItem(PiaItemRequest request) {
@@ -92,6 +100,56 @@ public class PiaShopService {
                 .map(PiaItemResponse::fromEntity)
                 .collect(Collectors.toList());
     }
+
+
+    public void purchasePiaItem(Long userId, PurchasePiaItemRequest request) {
+
+
+        // 1. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
+
+        // 2. 아이템 조회
+        Long piaItemId = Long.parseLong(request.getItemId());
+        PiaItem piaItem = piaItemRepository.findById(piaItemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_AUCTION_NOT_FOUND));
+
+        // 3. 총 구매 금액 계산
+        long totalPrice = piaItem.getPrice() * request.getQuantity();
+        if (user.getPia() < totalPrice) {
+            throw new CustomException(ErrorCode.E_400_INSUFFICIENT_PIA);
+        }
+
+        // 4. UserPiaItem 조회 및 수량 업데이트
+        UserPiaItem userPiaItem = userPiaItemRepository.findByUserAndPiaItem(user, piaItem)
+                .orElseGet(() -> {
+                    UserPiaItem newItem = new UserPiaItem();
+                    newItem.setUser(user);
+                    newItem.setPiaItem(piaItem);
+                    newItem.setQuantity(0L);
+                    return newItem;
+                });
+
+        userPiaItem.setQuantity(userPiaItem.getQuantity() + request.getQuantity());
+        userPiaItemRepository.save(userPiaItem);
+
+        // 5. 유저 금액 차감
+        user.setPia(user.getPia() - totalPrice);
+        userRepository.save(user);
+
+        // 6. 구매 로그 기록
+        PiaItemPurchaseLog log = new PiaItemPurchaseLog();
+        log.setUser(user);
+        log.setPiaItem(piaItem);
+        log.setPrice(totalPrice);
+        purchaseLogRepository.save(log);
+    }
+
+
+
+
+
+
 
 
 }

--- a/src/main/java/com/scriptopia/demo/service/PiaShopService.java
+++ b/src/main/java/com/scriptopia/demo/service/PiaShopService.java
@@ -11,6 +11,7 @@ import com.scriptopia.demo.dto.piashop.PurchasePiaItemRequest;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.PiaItemRepository;
+import com.scriptopia.demo.repository.PurchaseLogRepository;
 import com.scriptopia.demo.repository.UserPiaItemRepository;
 import com.scriptopia.demo.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class PiaShopService {
     private final PiaItemRepository piaItemRepository;
     private final UserRepository userRepository;
     private final UserPiaItemRepository userPiaItemRepository;
+    private final PurchaseLogRepository purchaseLogRepository;
 
     @Transactional
     public String createPiaItem(PiaItemRequest request) {
@@ -102,15 +104,17 @@ public class PiaShopService {
     }
 
 
+    @Transactional
     public void purchasePiaItem(Long userId, PurchasePiaItemRequest request) {
 
+        // uuid 로 사용할 것이기 때문에 임시임
+        Long piaItemId = Long.valueOf(request.getItemId());
 
         // 1. 유저 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
 
         // 2. 아이템 조회
-        Long piaItemId = Long.parseLong(request.getItemId());
         PiaItem piaItem = piaItemRepository.findById(piaItemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_AUCTION_NOT_FOUND));
 
@@ -144,12 +148,6 @@ public class PiaShopService {
         log.setPrice(totalPrice);
         purchaseLogRepository.save(log);
     }
-
-
-
-
-
-
 
 
 }


### PR DESCRIPTION
## 📑 기능 설명  
사용자가 Shop에서 원하는 Pia 상품을 구매할 수 있는 API입니다.  
구매 요청 시 결제 처리 후 사용자의 계정에 Pia가 충전되며, 주문 내역이 기록됩니다.  

## ✅ 작업할 내용  
- [x] POST /shops/pia/orders 엔드포인트 생성  
- [x] 요청 바디 유효성 검증 (itemId, 결제 정보 등)  
- [x] 상품 존재 여부 및 재고 확인  
- [x] 결제 처리 로직 수행  
- [x] 주문 내역(DB)에 기록  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 사용자가 Shop에서 간편하게 Pia 상품 구매 가능  
- 구매 완료 시 자동으로 계정에 Pia 충전  
- 주문 내역 기록으로 구매 추적 가능  

## 📎 추가 정보  
- 엔드포인트: `POST /shops/pia/orders`  
- 요청 바디 예시:
```json
{
  "itemId": 1,
  "quantity": 2 
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 인증된 PIA 아이템 구매 API 추가(POST /user/shops/pia/item/purchase): 수량 구매, 잔액 차감, 보유 아이템 수량 자동 갱신, 구매 내역 기록

- 변경 사항
  - PIA 아이템 목록 조회 경로를 사용자 범위로 변경: GET /user/shops/pia/items (이제 인증 필요)

- 주의
  - 기존 공개 경로를 사용하던 클라이언트는 새 사용자 경로로 업데이트가 필요합니다 (호환성 영향)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->