### PR TITLE
Feature/35 reset password

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/AuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuthController.java
@@ -31,6 +31,13 @@ public class AuthController {
     private static final String COOKIE_SAMESITE = "None";
 
 
+    @PatchMapping("public/auth/password/reset")
+    public ResponseEntity<?> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        localAccountService.resetPassword(request.getToken(), request.getNewPassword());
+
+        return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
+    }
+
     @PostMapping("/public/auth/password/send-link")
     public ResponseEntity<?> sendResetMail(@Valid @RequestBody SendCodeRequest request){
 

--- a/src/main/java/com/scriptopia/demo/controller/AuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuthController.java
@@ -31,6 +31,14 @@ public class AuthController {
     private static final String COOKIE_SAMESITE = "None";
 
 
+    @PostMapping("/public/auth/password/send-link")
+    public ResponseEntity<?> sendResetMail(@Valid @RequestBody SendCodeRequest request){
+
+        localAccountService.sendResetPasswordMail(request.getEmail());
+
+        return ResponseEntity.ok("비밀번호 초기화 링크를 전송했습니다.");
+    }
+
     @PostMapping("/public/auth/verify-email")
     public ResponseEntity<?> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
 

--- a/src/main/java/com/scriptopia/demo/dto/localaccount/ResetPasswordRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/localaccount/ResetPasswordRequest.java
@@ -1,0 +1,24 @@
+package com.scriptopia.demo.dto.localaccount;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResetPasswordRequest {
+
+    private String token;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 20, message = "비밀번호는 8~20자리여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*\\d)(?=.*[!@#$%^&*()_+=\\-{}\\[\\]:;\"'<>,.?/]).+$",
+            message = "비밀번호는 소문자, 숫자, 특수문자를 포함해야 합니다."
+    )
+    private String newPassword;
+}

--- a/src/main/java/com/scriptopia/demo/dto/localaccount/SendResetMailRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/localaccount/SendResetMailRequest.java
@@ -1,0 +1,17 @@
+package com.scriptopia.demo.dto.localaccount;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class SendResetMailRequest {
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
+++ b/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
@@ -48,7 +48,7 @@ public class LocalAccountService {
 
     private static final Pattern WS = Pattern.compile("[\\s\\p{Z}\\u200B\\u200C\\u200D\\uFEFF]");
 
-    private static final long TOKEN_EXPIRATION = 30L;
+    private static final long TOKEN_EXPIRATION = 30;
 
 
 

--- a/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
+++ b/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
@@ -53,6 +53,23 @@ public class LocalAccountService {
 
 
     @Transactional
+    public void resetPassword(String token,String newPassword) {
+        String key = "reset:token:" + token;
+        String email = redisTemplate.opsForValue().get(key);
+
+        if (email == null) {
+            throw new CustomException(ErrorCode.E_401);
+        }
+
+        LocalAccount localAccount = localAccountRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
+
+        localAccount.setPassword(passwordEncoder.encode(newPassword));
+        localAccountRepository.save(localAccount);
+
+        redisTemplate.delete(key);
+    }
+
+    @Transactional
     public void verifyEmail(VerifyEmailRequest request) {
         String email = request.getEmail();
 

--- a/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
+++ b/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
@@ -47,6 +48,9 @@ public class LocalAccountService {
 
     private static final Pattern WS = Pattern.compile("[\\s\\p{Z}\\u200B\\u200C\\u200D\\uFEFF]");
 
+    private static final long TOKEN_EXPIRATION = 30L;
+
+
 
     @Transactional
     public void verifyEmail(VerifyEmailRequest request) {
@@ -66,6 +70,17 @@ public class LocalAccountService {
     }
 
     @Transactional
+    public void sendResetPasswordMail(String email) {
+
+        if (!localAccountRepository.existsByEmail(email)){
+            throw new CustomException(ErrorCode.E_404_USER_NOT_FOUND);
+        }
+
+        String resetToken = createResetToken(email);
+        mailService.sendResetLink(email, resetToken);
+    }
+
+    @Transactional
     public void verifyCode(String email, String inputCode) {
 
         if (length(inputCode) != 6){
@@ -76,15 +91,16 @@ public class LocalAccountService {
 
         if (savedCode != null && savedCode.equals(inputCode)) {
             // 인증 완료 후 30분 유지
-            redisTemplate.opsForValue().set("email:verified:" + email, "true", 30, TimeUnit.MINUTES);
+            redisTemplate.opsForValue().set("email:verified:" + email, "true", TOKEN_EXPIRATION, TimeUnit.MINUTES);
             redisTemplate.delete("email:verify:" + email); // 코드 제거
         }
         else{
             throw new CustomException(ErrorCode.E_401_CODE_MISMATCH);
         }
 
-
     }
+
+
 
     @Transactional
     public void register(RegisterRequest request) {
@@ -195,6 +211,15 @@ public class LocalAccountService {
 
         localAccount.setPassword(passwordEncoder.encode(request.getNewPassword()));
 
+    }
+
+    public String createResetToken(String email) {
+        String token = UUID.randomUUID().toString();
+
+        redisTemplate.opsForValue()
+                .set("reset:token" + token, email, TOKEN_EXPIRATION, TimeUnit.MINUTES);
+
+        return token;
     }
 
 

--- a/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
+++ b/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
@@ -56,7 +56,7 @@ public class LocalAccountService {
     public void resetPassword(String token,String newPassword) {
         String key = "reset:token:" + token;
         String email = redisTemplate.opsForValue().get(key);
-
+        System.out.println(key);
         if (email == null) {
             throw new CustomException(ErrorCode.E_401);
         }
@@ -234,7 +234,7 @@ public class LocalAccountService {
         String token = UUID.randomUUID().toString();
 
         redisTemplate.opsForValue()
-                .set("reset:token" + token, email, TOKEN_EXPIRATION, TimeUnit.MINUTES);
+                .set("reset:token:" + token, email, TOKEN_EXPIRATION, TimeUnit.MINUTES);
 
         return token;
     }

--- a/src/main/java/com/scriptopia/demo/service/MailService.java
+++ b/src/main/java/com/scriptopia/demo/service/MailService.java
@@ -1,5 +1,8 @@
 package com.scriptopia.demo.service;
 
+import com.scriptopia.demo.exception.CustomException;
+import com.scriptopia.demo.exception.ErrorCode;
+import com.scriptopia.demo.repository.LocalAccountRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -14,17 +17,21 @@ import java.util.concurrent.TimeUnit;
 public class MailService {
     private final JavaMailSender mailSender;
     private final StringRedisTemplate redisTemplate;
+    private final LocalAccountRepository localAccountRepository;
     @Value("${spring.mail.username}")
     private String fromEmail;
 
-    public void sendVerificationCode(String toEmail, String code) {
-        SimpleMailMessage message = new SimpleMailMessage();
-        message.setTo(toEmail);
-        message.setFrom(fromEmail);
-        message.setSubject("회원가입 이메일 인증번호");
-        message.setText("인증번호: " + code + "\n5분 이내에 입력해주세요.");
-        mailSender.send(message);
+    @Value("${reset-url}")
+    private String resetUrl;
 
+    public void sendVerificationCode(String toEmail, String code) {
+        mailSender.send(initMessage(
+                toEmail,
+                fromEmail,
+                "[Scriptopia] 회원가입 이메일 인증번호",
+                "인증번호: " + code + "\n5분 이내에 입력해주세요."
+
+        ));
     }
 
     public void saveCode(String email, String code) {
@@ -36,6 +43,26 @@ public class MailService {
         );
     }
 
+    public void sendResetLink(String toEmail, String token) {
+
+        String link = resetUrl + "?token=" + token;
+        mailSender.send(initMessage(
+                toEmail,
+                fromEmail,
+                "[Scriptopia] 비밀번호 재설정 안내",
+                "아래 링크를 클릭하여 비밀번호를 변경하세요:\n" +link
+        ));
+    }
+
+
+    public SimpleMailMessage initMessage(String toEmail, String fromEmail, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(toEmail);
+        message.setFrom(fromEmail);
+        message.setSubject(subject);
+        message.setText(text);
+        return message;
+    }
     public String getCode(String email) {
         return redisTemplate.opsForValue().get("email:verify" + email);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,6 @@ spring:
     password: ${SPRING_MAIL_PASSWORD}
     properties:
       mail:
-        debug: true
         smtp:
           auth: true
           starttls:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,9 @@ spring:
   data:
     mongodb:
       uri: mongodb://root:tiger@localhost:27017/scriptopia_mongo?authSource=admin
+    redis:
+      host: 127.0.0.1
+      port: 6379
   mail:
     host: smtp.gmail.com
     port: 587
@@ -28,10 +31,12 @@ spring:
     password: ${SPRING_MAIL_PASSWORD}
     properties:
       mail:
+        debug: true
         smtp:
           auth: true
           starttls:
             enable: true
+
 
 auth:
   jwt:
@@ -39,5 +44,3 @@ auth:
     access-exp-seconds: 1800
     refresh-exp-seconds: 1209600
     secret: ${JWT_SECRET}
-
-


### PR DESCRIPTION
## 🚀 관련 이슈

Close #36 
Close #35 

## 📑 PR 설명
비밀번호 재설정 로직 구현

## ✏️ 작업 내용
1. 비밀번호 재설정 메일 전송
2. 메일을 통해 재설정 토큰, 변경할 비밀번호 검증
3. 비밀번호 정책 예외 처리
4. 비밀번호 재설정
5. 
## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 빌드 통과 확인
- [x] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 이메일 입력으로 비밀번호 재설정 링크를 요청할 수 있습니다.
  - 수신한 토큰으로 비밀번호를 재설정할 수 있습니다.
  - 비밀번호 규칙 적용: 8–20자, 소문자·숫자·특수문자 각 1자 이상 필요.
  - 안내 메일 제목에 [Scriptopia] 접두어가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->