### PR TITLE
Feature/103 game creation item usage

### DIFF
--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -80,7 +80,13 @@ public enum ErrorCode {
     //500 Internal Server Error
     E_500("E_500000", "예상치 못한 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     E_500_TOKEN_HASHING_FAILED("E_500001","리프레쉬 토큰 해싱에 실패했습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
-    E_500_EXTERNAL_API_ERROR("E500001", "외부 게임 API 호출에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    E_500_EXTERNAL_API_ERROR("E500002", "외부 게임 API 호출에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    E_500_DATABASE_ERROR("E500003", "데이터베이스 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    E_500_TOKEN_CREATION_FAILED("E500004", "인증 토큰 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    E_500_TOKEN_STORAGE_FAILED("E500005", "리프레시 토큰 저장에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    //502 BAD_GATEWAY
+    E_502_OAUTH_SERVER_ERROR("E502001", "소셜 로그인 서버와의 통신에 실패했습니다.", HttpStatus.BAD_GATEWAY);
 
 
     private final String code;

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     E_400_PIA_ITEM_DUPLICATE("E400019", "이미 존재하는 PIA 아이템 이름입니다.", HttpStatus.BAD_REQUEST),
     E_400_INVALID_REQUEST("E400020", "이름이나, 금액이 비어있습니다.", HttpStatus.BAD_REQUEST),
     E_400_GAME_ALREADY_IN_PROGRESS("E400021", "진행 중인 게임이 이미 존재합니다.", HttpStatus.BAD_REQUEST),
+    E_400_ITEM_NO_USES_LEFT("E400025", "아이템 사용 가능 횟수가 남아있지 않습니다.", HttpStatus.BAD_REQUEST),
 
 
 

--- a/src/main/java/com/scriptopia/demo/service/AuctionService.java
+++ b/src/main/java/com/scriptopia/demo/service/AuctionService.java
@@ -54,6 +54,10 @@ public class AuctionService {
             throw new CustomException(ErrorCode.E_400_ITEM_NOT_TRADE_ABLE);
         }
 
+        if (userItem.getRemainingUses() <= 0){
+            throw new CustomException(ErrorCode.E_400_ITEM_NO_USES_LEFT);
+        }
+
         // 이미 경매장에 등록되어 있는지 확인
         if (auctionRepository.existsByUserItem(userItem)) {
             throw new CustomException(ErrorCode.E_400_ITEM_ALREADY_REGISTERED);

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -86,6 +86,8 @@ public class GameSessionService {
             Long itemId = Long.parseLong(request.getItemId());
             userItem = userItemRepository.findByUserIdAndItemDefId(userId, itemId)
                     .orElseThrow(() -> new CustomException(ErrorCode.E_400_ITEM_NOT_OWNED));
+
+
         }
 
 
@@ -247,7 +249,7 @@ public class GameSessionService {
             }
         }
 
-// 3. MongoSession 저장
+        // 3. MongoSession 저장
         mongoSession.setInventory(mongoInventory);
         mongoSession.setItemDef(mongoItemDefs);
 

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -87,7 +87,9 @@ public class GameSessionService {
             userItem = userItemRepository.findByUserIdAndItemDefId(userId, itemId)
                     .orElseThrow(() -> new CustomException(ErrorCode.E_400_ITEM_NOT_OWNED));
 
-
+            if (userItem.getRemainingUses() <= 0) {
+                throw new CustomException(ErrorCode.E_400_ITEM_NO_USES_LEFT);
+            }
         }
 
 
@@ -308,6 +310,10 @@ public class GameSessionService {
         mysqlSession.setMongoId(savedMongo.getId());
         gameSessionRepository.save(mysqlSession);
 
+        if (userItem != null) {
+            userItem.setRemainingUses(userItem.getRemainingUses() - 1);
+            userItemRepository.save(userItem);
+        }
 
         StartGameResponse startGameResponse = new StartGameResponse(
                 "게임이 생성되었습니다.",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## 📑 기능 설명  
새로운 게임을 생성할 때 초기화 로직을 추가로 수행해야 합니다.  
게임 시작 시 선택된 아이템(itemDefId)의 사용 횟수를 차감하고, 올바른 캐릭터 및 아이템 데이터로 게임이 초기화되도록 합니다.  

## ✅ 작업할 내용  
- [x] 게임 생성 로직(`POST /games`) 수정  
- [x] 시작 아이템의 남은 사용 횟수를 1 차감  
- [x] 변경된 아이템 상태를 DB에 저장  
- [x] 남은 사용 횟수가 0인 경우 게임 시작 불가 (400 Bad Request 반환)  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 사용 불가능한 아이템으로 게임을 시작하는 문제 방지  
- 아이템 사용 횟수의 일관성 및 신뢰성 보장  
- 게임 시작 시 안정성과 완성도 향상  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 경매 등록 및 게임 시작 시 아이템 남은 사용 횟수 검증 추가: 0회일 경우 요청이 거절되고 안내 오류 메시지가 표시됩니다.
  * 게임 시작 시 아이템을 사용하면 남은 사용 횟수가 자동으로 1 감소합니다.
* 버그 수정
  * 사용 가능 횟수가 소진된 아이템이 경매나 게임에 잘못 사용되던 상황을 방지했습니다.
* 작업
  * 애플리케이션 실행 시 DB 스키마 전략을 create에서 update로 변경해 기존 데이터가 보존되도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->