### PR TITLE
[Feature] 공유된 게임 상세 조회

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
@@ -1,0 +1,18 @@
+package com.scriptopia.demo.controller;
+
+import com.scriptopia.demo.service.SharedGameService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/public/games/shared")
+@RequiredArgsConstructor
+public class PublicSharedGameController {
+    private final SharedGameService sharedGameService;
+
+    @GetMapping("/{sharedGameId}")
+    public ResponseEntity<?> getSharedGameDetail(@PathVariable Long sharedGameId) {
+        return sharedGameService.getDetailedSharedGame(sharedGameId);
+    }
+}

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
@@ -1,0 +1,40 @@
+package com.scriptopia.demo.dto.sharedgame;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+public class PublicSharedGameDetailResponse {
+    private Long sharedGameId;
+    private String nickname;
+    private String thumbnailUrl;
+    private Long totalPlayed;
+    private String title;
+    private String worldView;
+    private String backgroundStory;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private LocalDateTime sharedAt;
+    private List<TagDto> tags;
+    private List<TopScoreDto> topScores;
+
+    @Data
+    public static class TagDto {
+        private String tagName;
+
+        public TagDto(String tagName) {
+            this.tagName = tagName;
+        }
+    }
+
+    @Data
+    public static class TopScoreDto {
+        private String nickname;
+        private Float score;
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
@@ -5,10 +5,14 @@ import com.scriptopia.demo.domain.SharedGameScore;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface SharedGameScoreRepository extends JpaRepository<SharedGameScore, Long> {
     @Query("Select count(s) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
     long countBySharedGameId(Long sharedGameId);
 
     @Query("select max(s.score) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
     Long maxScoreBySharedGameId(Long sharedGameId);
+
+    List<SharedGameScore> findAllBySharedGameIdOrderByScoreDescCreatedAtDesc(Long sharedGameId);
 }


### PR DESCRIPTION
## 🚀 관련 이슈

Close #102 

## 📑 PR 설명
탐색 페이지(토큰 없어도 가능)에서 사용자가 게임 상세보기를 눌렀을때 해당 상세 정보들을 확인할 수 있는 api

## ✏️ 작업 내용
SharedGameService 기능 추가, PublicSharedGameController 추가, PublicSharedGameController 기능 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트
