### PR TITLE
[Feature] 공유된 게임 태그 조회

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
@@ -15,4 +15,9 @@ public class PublicSharedGameController {
     public ResponseEntity<?> getSharedGameDetail(@PathVariable Long sharedGameId) {
         return sharedGameService.getDetailedSharedGame(sharedGameId);
     }
+
+    @GetMapping("/tags")
+    public ResponseEntity<?> getSharedGameTags() {
+        return sharedGameService.getTag();
+    }
 }

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicTagDefResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicTagDefResponse.java
@@ -1,0 +1,11 @@
+package com.scriptopia.demo.dto.sharedgame;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PublicTagDefResponse {
+    private Long id;
+    private String tagName;
+}

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -1,11 +1,9 @@
 package com.scriptopia.demo.service;
 
-import com.scriptopia.demo.domain.History;
-import com.scriptopia.demo.domain.SharedGame;
-import com.scriptopia.demo.domain.SharedGameScore;
-import com.scriptopia.demo.domain.User;
+import com.scriptopia.demo.domain.*;
 import com.scriptopia.demo.dto.sharedgame.MySharedGameResponse;
 import com.scriptopia.demo.dto.sharedgame.PublicSharedGameDetailResponse;
+import com.scriptopia.demo.dto.sharedgame.PublicTagDefResponse;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.*;
@@ -25,6 +23,7 @@ public class SharedGameService {
     private final SharedGameScoreRepository sharedGameScoreRepository;
     private final SharedGameFavoriteRepository sharedGameFavoriteRepository;
     private final GameTagRepository gameTagRepository;
+    private final TagDefRepository tagDefRepository;
 
     @Transactional
     public ResponseEntity<?> saveSharedGame(Long Id, Long historyId) {
@@ -115,5 +114,15 @@ public class SharedGameService {
         }).toList() );
 
         return ResponseEntity.ok(dto);
+    }
+
+    public ResponseEntity<?> getTag() {
+        List<TagDef> tag = tagDefRepository.findAll();
+
+        List<PublicTagDefResponse> dtoList = tag.stream()
+                .map(t -> new PublicTagDefResponse(t.getId(), t.getTagName()))
+                .toList();
+
+        return ResponseEntity.ok(dtoList);
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈

Close #109 

## 📑 PR 설명
db에 있는 게임 태그들 조회

## ✏️ 작업 내용
PublicTagDefResponse dto 추가, service 로직 추가, controller 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 공개 API에 공유 게임 태그 조회 엔드포인트를 추가했습니다 (/public/games/shared/tags). 클라이언트는 전체 태그 목록을 가져올 수 있습니다.
  - 응답은 태그의 식별자와 이름을 포함한 단순 목록을 반환합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->