### PR TITLE
[Feature] 게임 세션 조회

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -16,23 +16,15 @@ public class GameSessionController {
     private final GameSessionService gameSessionService;
     private final HistoryService historyService;
 
-    @PostMapping("/{sessionId}/exit")
-    public ResponseEntity<?> createGameSession(Authentication authentication, @PathVariable String sessionId) {
+    @PostMapping("/{gameId}/exit")
+    public ResponseEntity<?> createGameSession(Authentication authentication, @PathVariable String gameId) {
         // 게임 세션 정보 저장
         Long userId = Long.valueOf(authentication.getName());
 
-        return gameSessionService.saveGameSession(userId, sessionId);
+        return gameSessionService.saveGameSession(userId, gameId);
     }
 
-    // 정보 불러오기
-    @GetMapping
-    public ResponseEntity<?> loadGameSession(Authentication authentication) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        return gameSessionService.getGameSession(userId);
-    }
-
-    @DeleteMapping("/{sessionId}")
+    @DeleteMapping("/{gameId}")
     public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String sessionId) {
         Long userId = Long.valueOf(authentication.getName());
 

--- a/src/main/java/com/scriptopia/demo/controller/MyPageController.java
+++ b/src/main/java/com/scriptopia/demo/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.dto.history.HistoryPageResponse;
+import com.scriptopia.demo.service.GameSessionService;
 import com.scriptopia.demo.service.HistoryService;
 import com.scriptopia.demo.service.SharedGameService;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import java.util.List;
 public class MyPageController {
     private final HistoryService historyService;
     private final SharedGameService sharedGameService;
+    private final GameSessionService gameSessionService;
 
     @GetMapping("/user/my-page/history")
     public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) Long lastId,
@@ -46,5 +48,19 @@ public class MyPageController {
         sharedGameService.deletesharedGame(userId, gameid);
 
         return ResponseEntity.ok("게임이 삭제되었습니다.");
+    }
+
+    @GetMapping("/user/my-page/game")
+    public ResponseEntity<?> loadGameSession(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return gameSessionService.getGameSession(userId);
+    }
+
+    @DeleteMapping("/user/my-page/game/{gameId}")
+    public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String gameId) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return gameSessionService.deleteGameSession(userId, gameId);
     }
 }

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -28,7 +28,6 @@ public class GameSessionService {
     private final RestTemplate restTemplate;
     private final GameSessionMongoRepository gameSessionMongoRepository;
     private final UserItemRepository userItemRepository;
-    private final ItemDefRepository itemDefRepository;
 
     public ResponseEntity<?> getGameSession(Long userid) {
         User user = userRepository.findById(userid)


### PR DESCRIPTION
## 🚀 관련 이슈

Close #111 

## 📑 PR 설명
사용자 게임 세션 조회 id, mogoid 반환

## ✏️ 작업 내용
service 로직 추가, controller 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 마이페이지에 게임 세션 관리 추가: 인증 사용자 기준으로 세션 조회(GET /user/my-page/game)와 삭제(DELETE /user/my-page/game/{gameId}) 지원.
- 리팩터
  - 게임 세션 관련 엔드포인트 경로를 정리하여 식별자를 gameId로 일관화.
  - 기존 세션 조회 엔드포인트를 마이페이지 경로로 이전해 사용자 중심의 접근성 개선.
- 잡무
  - 내부 의존성 정리 및 불필요한 구성 요소 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->