### PR TITLE
[Feature] 모든 공유된 게임 조회

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -1,10 +1,14 @@
 package com.scriptopia.demo.controller;
 
+import com.scriptopia.demo.dto.sharedgame.CursorPage;
+import com.scriptopia.demo.dto.sharedgame.PublicSharedGameResponse;
 import com.scriptopia.demo.service.SharedGameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -33,5 +37,15 @@ public class SharedGameController {
         sharedGameService.deletesharedGame(userId, gameid);
 
         return ResponseEntity.ok("게임이 삭제되었습니다.");
+    }
+
+    @GetMapping("/public/shared")
+    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
+                                                                                     @RequestParam(required = false) Long lastId,
+                                                                                     @RequestParam(defaultValue = "20") int size,
+                                                                                     @RequestParam(required = false) List<Long> tagIds,
+                                                                                     @RequestParam(required = false) String q) {
+        Long viewerId = (authentication == null) ? null : Long.valueOf(authentication.getName());
+        return sharedGameService.getPublicSharedGames(viewerId, lastId, size, tagIds, q);
     }
 }

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/CursorPage.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/CursorPage.java
@@ -1,0 +1,5 @@
+package com.scriptopia.demo.dto.sharedgame;
+
+import java.util.List;
+
+public record CursorPage<T>(List<T> items, Long nextCursor, boolean hasNext) {}

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
@@ -1,0 +1,14 @@
+package com.scriptopia.demo.dto.sharedgame;
+
+import lombok.Data;
+
+@Data
+public class PublicSharedGameResponse {
+    private Long sharedGameId;
+    private String thumbnailUrl;
+    private boolean isLiked;
+    private Long likeCount;
+    private Long totalPlayCount;
+    private String title;
+    private Float topScore;
+}

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
@@ -2,6 +2,9 @@ package com.scriptopia.demo.dto.sharedgame;
 
 import lombok.Data;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Data
 public class PublicSharedGameResponse {
     private Long sharedGameId;
@@ -10,5 +13,9 @@ public class PublicSharedGameResponse {
     private Long likeCount;
     private Long totalPlayCount;
     private String title;
-    private Float topScore;
+    private Long topScore;
+    private LocalDateTime sharedAt;
+
+    private List<TagDto> tags;
+
 }

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/TagDto.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/TagDto.java
@@ -1,0 +1,11 @@
+package com.scriptopia.demo.dto.sharedgame;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TagDto {
+    private Long tagId;
+    private String tagName;
+}

--- a/src/main/java/com/scriptopia/demo/repository/GameTagRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/GameTagRepository.java
@@ -3,6 +3,8 @@ package com.scriptopia.demo.repository;
 import com.scriptopia.demo.domain.GameTag;
 import com.scriptopia.demo.dto.TagDef.TagDefCreateRequest;
 import com.scriptopia.demo.dto.sharedgame.MySharedGameResponse;
+import com.scriptopia.demo.dto.sharedgame.PublicSharedGameResponse;
+import com.scriptopia.demo.dto.sharedgame.TagDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +20,13 @@ public interface GameTagRepository extends JpaRepository<GameTag, Long> {
     @Query("select new com.scriptopia.demo.dto.TagDef.TagDefCreateRequest(gt.tagDef.tagName) " +
             "from GameTag gt where gt.sharedGame.id = :sharedGameId")
     List<TagDefCreateRequest> findTagsBySharedGameId(@Param("sharedGameId") Long sharedGameId);
+
+    @Query("""
+    select new com.scriptopia.demo.dto.sharedgame.TagDto(td.id, td.tagName)
+    from GameTag gt
+    join gt.tagDef td
+    where gt.sharedGame.id = :sharedGameId
+    order by td.tagName asc
+""")
+    List<TagDto> findTagDtosBySharedGameId(@Param("sharedGameId") Long sharedGameId);
 }

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
@@ -2,11 +2,54 @@ package com.scriptopia.demo.repository;
 
 import com.scriptopia.demo.domain.PiaItem;
 import com.scriptopia.demo.domain.SharedGame;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SharedGameRepository extends JpaRepository<SharedGame, Long> {
     List<SharedGame> findAllByUserId(Long userId);
 
+    // 기본(전체)
+    @Query("""
+        select g from SharedGame g
+        where (:lastId is null or g.id < :lastId)
+        order by g.id desc
+    """)
+    Page<SharedGame> pageAll(@Param("lastId") Long lastId, Pageable pageable);
+
+    // 🔎 검색 전용 (태그 무시)
+    @Query("""
+        select g from SharedGame g
+        where (:lastId is null or g.id < :lastId)
+          and (
+            lower(g.title) like lower(concat('%', :q, '%'))
+            or lower(g.worldView) like lower(concat('%', :q, '%'))
+            or lower(g.backgroundStory) like lower(concat('%', :q, '%'))
+          )
+        order by g.id desc
+    """)
+    Page<SharedGame> pageSearchOnly(@Param("lastId") Long lastId,
+                                    @Param("q") String q,
+                                    Pageable pageable);
+
+
+    // 🏷 태그 ALL 전용 (검색 없음)
+    @Query("""
+        select g from SharedGame g
+        join GameTag gt on gt.sharedGame = g
+        join TagDef td on td = gt.tagDef
+        where (:lastId is null or g.id < :lastId)
+          and td.id in :tagIds
+        group by g.id
+        having count(distinct td.id) = :tagCount
+        order by g.id desc
+    """)
+    Page<SharedGame> pageByAllTagsOnly(@Param("lastId") Long lastId,
+                                       @Param("tagIds") List<Long> tagIds,
+                                       @Param("tagCount") long tagCount,
+                                       Pageable pageable);
 }

--- a/src/main/java/com/scriptopia/demo/service/HistoryService.java
+++ b/src/main/java/com/scriptopia/demo/service/HistoryService.java
@@ -129,11 +129,14 @@ public class HistoryService {
 
     @Transactional(readOnly = true)
     public ResponseEntity<List<HistoryPageResponse>> fetchMyHisotry(Long userId, Long lastId, int size) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
+
         PageRequest pr = PageRequest.of(0, size);
         Page<History> page;
 
-        if(lastId == null) page = historyRepository.findByUserIdOrderByIdDesc(userId, pr);
-        else page = historyRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, lastId, pr);
+        if(lastId == null) page = historyRepository.findByUserIdOrderByIdDesc(user.getId(), pr);
+        else page = historyRepository.findByUserIdAndIdLessThanOrderByIdDesc(user.getId(), lastId, pr);
 
         return ResponseEntity.ok(page.getContent().stream().map(HistoryPageResponse::from).toList());
     }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -84,4 +84,8 @@ public class SharedGameService {
 
         sharedGameRepository.delete(game);
     }
+
+//    public ResponseEntity<?> getPublicSharedGame() {
+//
+//    }
 }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -3,11 +3,16 @@ package com.scriptopia.demo.service;
 import com.scriptopia.demo.domain.History;
 import com.scriptopia.demo.domain.SharedGame;
 import com.scriptopia.demo.domain.User;
+import com.scriptopia.demo.dto.sharedgame.CursorPage;
 import com.scriptopia.demo.dto.sharedgame.MySharedGameResponse;
+import com.scriptopia.demo.dto.sharedgame.PublicSharedGameResponse;
+import com.scriptopia.demo.dto.sharedgame.TagDto;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -85,7 +90,48 @@ public class SharedGameService {
         sharedGameRepository.delete(game);
     }
 
-//    public ResponseEntity<?> getPublicSharedGame() {
-//
-//    }
+    @Transactional(readOnly = true)
+    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Long userId, Long lastId, int size,
+                                                                                     List<Long> tagIds, String q) {
+
+        PageRequest pr = PageRequest.of(0, size);
+        Page<SharedGame> page;
+
+        boolean hasQ = q != null && q.isBlank();
+        boolean hasTags = tagIds != null && !tagIds.isEmpty();
+
+        if(hasQ) {
+            page = sharedGameRepository.pageSearchOnly(lastId, q.trim(), pr);
+        }
+        else if(hasTags) {
+            page = sharedGameRepository.pageByAllTagsOnly(lastId, tagIds, tagIds.size(), pr);
+        }
+        else {
+            page = sharedGameRepository.pageAll(lastId, pr);
+        }
+
+        var items = page.getContent().stream().map(g -> {
+            var dto = new PublicSharedGameResponse();
+            dto.setSharedGameId(g.getId());
+            dto.setThumbnailUrl(g.getThumbnailUrl());
+            dto.setTitle(g.getTitle());
+            dto.setTopScore(sharedGameScoreRepository.maxScoreBySharedGameId(g.getId()));
+            dto.setSharedAt(g.getSharedAt());
+
+            dto.setTotalPlayCount(sharedGameScoreRepository.countBySharedGameId(g.getId()));
+            dto.setLikeCount(sharedGameFavoriteRepository.countBySharedGameId(g.getId()));
+
+            if(userId != null) {
+                dto.setLiked(sharedGameFavoriteRepository.existsByUserIdAndSharedGameId(userId, g.getId()));
+            }
+
+            List<TagDto> tags = gameTagRepository.findTagDtosBySharedGameId(g.getId());
+            dto.setTags(tags);
+
+            return dto;
+        }).toList();
+
+        Long nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getSharedGameId();
+        return ResponseEntity.ok(new CursorPage<>(items, nextCursor, page.hasNext()));
+    }
 }


### PR DESCRIPTION
## 🚀 관련 이슈

Close #49 

## 📑 PR 설명
공유된 게임 리스트 태그로 필터링, 검색어 입력해서 필터링하여 검색할 수 있음

## ✏️ 작업 내용
service 추가 Repository 로직 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 공개 공유 게임 목록 제공: 최신순 커서 기반 페이지네이션으로 탐색, 다음 커서와 더보기 여부 포함.
  - 필터링 지원: 태그 선택 및 검색어로 결과 좁히기.
  - 항목 정보 강화: 썸네일, 제목, 공유일, 태그, 최상위 점수, 총 플레이 수, 좋아요 수, (로그인 시) 좋아요 여부 제공.

- 버그 수정
  - 내 기록 조회 시 존재하지 않는 사용자에 대해 올바른 404 오류를 반환하도록 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->