### PR TITLE
[Feature] 공유게임 UUID 필드 생성

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -52,10 +52,10 @@ public class GameSessionController {
      * 인증 관리 부분 끝나면 header에 token 꺼내오고 requestparameter session_id로 저장하게 수정
      */
     @PostMapping("/{gameId}/history")
-    public ResponseEntity<?> addHistory(@PathVariable String sid, Authentication authentication) {
+    public ResponseEntity<?> addHistory(@PathVariable String gameId, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 
-        return historyService.createHistory(userId, sid);
+        return historyService.createHistory(userId, gameId);
     }
 
     /** 개발용: 로컬 MongoDB에 더미 세션 한 건 심어서 테스트용 ObjectId 반환 */

--- a/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
@@ -26,7 +26,7 @@ public class PublicSharedGameController {
         return sharedGameService.getTag();
     }
 
-    @GetMapping("/check")
+    @GetMapping
     public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
                                                                                      @RequestParam(required = false) Long lastId,
                                                                                      @RequestParam(defaultValue = "20") int size,

--- a/src/main/java/com/scriptopia/demo/domain/SharedGame.java
+++ b/src/main/java/com/scriptopia/demo/domain/SharedGame.java
@@ -23,7 +23,7 @@ public class SharedGame {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
-    @Column(nullable = false, unique = true, columnDefinition = "BINARY(16)")
+    @Column(nullable = false, unique = true)
     private UUID uuid;
 
     private String thumbnailUrl;

--- a/src/main/java/com/scriptopia/demo/domain/SharedGame.java
+++ b/src/main/java/com/scriptopia/demo/domain/SharedGame.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 
 @Entity
@@ -22,6 +23,9 @@ public class SharedGame {
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
+    @Column(nullable = false, unique = true, columnDefinition = "BINARY(16)")
+    private UUID uuid;
+
     private String thumbnailUrl;
     private Long recommend = 0L;
     private Long totalPlayed = 0L;
@@ -35,6 +39,13 @@ public class SharedGame {
     @Column(columnDefinition = "TEXT")
     private String backgroundStory;
     private LocalDateTime sharedAt;
+
+    @PrePersist
+    public void generateUuid() {
+        if(uuid == null) {
+            uuid = UUID.randomUUID();
+        }
+    }
 
     public static SharedGame from(User user, History h) {
         SharedGame game = new SharedGame();

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/MySharedGameResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/MySharedGameResponse.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @Data
 public class MySharedGameResponse {
+    private String uuid;
     private String thumbnailUrl;
     private boolean recommand;
     private Long totalPlayed;

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
@@ -9,10 +9,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SharedGameRepository extends JpaRepository<SharedGame, Long> {
     @Query("select sg from SharedGame sg where sg.user.id = :userId")
     List<SharedGame> findAllByUserid(@Param("userId") Long userId);
+
+    @Query("select sg.id from SharedGame sg where sg.uuid = :uuid")
+    Long findByUuid(@Param("uuid") String uuid);
 
     // 기본(전체)
     @Query("""

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -52,6 +52,7 @@ public class SharedGameService {
 
         for(SharedGame game : games) {
             MySharedGameResponse dto = new MySharedGameResponse();
+            dto.setUuid(game.getUuid().toString());
             dto.setThumbnailUrl(game.getThumbnailUrl());
             dto.setTotalPlayed(sharedGameScoreRepository.countBySharedGameId(game.getId()));
             dto.setTitle(game.getTitle());


### PR DESCRIPTION
## 🚀 관련 이슈

Close #126

## 📑 PR 설명
공유게임 엔티티 UUID 필드 생성

## ✏️ 작업 내용
SharedGame UUID 필드 추가, Repository UUID -> ID 찾는 쿼리문 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 공유 게임에 UUID를 도입하고, “내 공유 게임” 응답에 uuid 필드를 추가해 식별과 공유를 간편화했습니다.
  * 공개 공유 게임 목록 API 엔드포인트를 /public/games/shared 로 단순화해 접근성을 개선했습니다.
* 버그 수정
  * 게임 히스토리 추가 API의 경로 변수 불일치로 호출이 실패하던 문제를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->