### PR TITLE
[Feature] 히스토리 UUID 생성

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/MyPageController.java
+++ b/src/main/java/com/scriptopia/demo/controller/MyPageController.java
@@ -23,12 +23,12 @@ public class MyPageController {
     계정관리 : 내 히스토리 조회 -> 무한스크롤
      */
     @GetMapping("/my-page/history")
-    public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) Long lastId,
+    public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) UUID lastId,
                                                                 @RequestParam(defaultValue = "10") int size,
                                                                 Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 
-        return historyService.fetchMyHisotry(userId, lastId, size);
+        return historyService.fetchMyHistory(userId, lastId, size);
     }
 
     /*

--- a/src/main/java/com/scriptopia/demo/controller/MyPageController.java
+++ b/src/main/java/com/scriptopia/demo/controller/MyPageController.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,7 +19,10 @@ public class MyPageController {
     private final SharedGameService sharedGameService;
     private final GameSessionService gameSessionService;
 
-    @GetMapping("/user/my-page/history")
+    /*
+    계정관리 : 내 히스토리 조회 -> 무한스크롤
+     */
+    @GetMapping("/my-page/history")
     public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) Long lastId,
                                                                 @RequestParam(defaultValue = "10") int size,
                                                                 Authentication authentication) {
@@ -27,37 +31,52 @@ public class MyPageController {
         return historyService.fetchMyHisotry(userId, lastId, size);
     }
 
-    @GetMapping("/user/my-page/games/shared")
+    /*
+    계정관리 : 내가 공유한 게임 조회
+     */
+    @GetMapping("/my-page/games/shared")
     public ResponseEntity<?> getMySharedGames(Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 
         return sharedGameService.getMySharedGames(userId);
     }
 
-    @PostMapping("/user/my-page/share/{hid}")
-    public ResponseEntity<?> share(Authentication authentication, @PathVariable Long hid) {
+    /*
+    계정관리 : 내 히스토리 공유하기
+     */
+    @PostMapping("/my-page/share/{uuid}")
+    public ResponseEntity<?> share(Authentication authentication, @PathVariable UUID uuid) {
         Long userId = Long.valueOf(authentication.getName());
 
-        return sharedGameService.saveSharedGame(userId, hid);
+        return sharedGameService.saveSharedGame(userId, uuid);
     }
 
-    @DeleteMapping("/user/my-page/share/{gameid}")
-    public ResponseEntity<?> delete(Authentication authentication, @PathVariable Long gameid) {
+    /*
+    계정관리 : 내가 공유한 게임 삭제
+     */
+    @DeleteMapping("/my-page/share/{uuid}")
+    public ResponseEntity<?> delete(Authentication authentication, @PathVariable UUID uuid) {
         Long userId = Long.valueOf(authentication.getName());
 
-        sharedGameService.deletesharedGame(userId, gameid);
+        sharedGameService.deletesharedGame(userId, uuid);
 
         return ResponseEntity.ok("게임이 삭제되었습니다.");
     }
 
-    @GetMapping("/user/my-page/game")
+    /*
+    계정관리 : 게임 세션(이어하기) 조회
+     */
+    @GetMapping("/my-page/game")
     public ResponseEntity<?> loadGameSession(Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 
         return gameSessionService.getGameSession(userId);
     }
 
-    @DeleteMapping("/user/my-page/game/{gameId}")
+    /*
+    계정관리 : 게임 세션(이어하기) 삭제
+     */
+    @DeleteMapping("/my-page/game/{gameId}")
     public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String gameId) {
         Long userId = Long.valueOf(authentication.getName());
 

--- a/src/main/java/com/scriptopia/demo/domain/History.java
+++ b/src/main/java/com/scriptopia/demo/domain/History.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -17,6 +18,9 @@ public class History {
 
     @Id @GeneratedValue
     private Long id;
+
+    @Column(nullable = false, unique = true)
+    private UUID uuid;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
@@ -56,6 +60,12 @@ public class History {
     private Long score;
     private LocalDateTime createdAt;
     private Boolean isShared;
+
+    @PrePersist
+    public void prePersist() {
+        if(uuid == null) uuid = UUID.randomUUID();
+        if(createdAt == null) createdAt = LocalDateTime.now();
+    }
 
     public History(User id, HistoryRequest req) {
         this.user = id;

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/MySharedGameResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/MySharedGameResponse.java
@@ -4,10 +4,11 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 public class MySharedGameResponse {
-    private String uuid;
+    private UUID shared_game_uuid;
     private String thumbnailUrl;
     private boolean recommand;
     private Long totalPlayed;

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -67,6 +67,7 @@ public enum ErrorCode {
     E_404_GAME_SESSION_NOT_FOUND("E404006", "게임을 불러올 수 없습니다.", HttpStatus.NOT_FOUND),
     E_404_STORED_GAME_NOT_FOUND("E404007", "저장된 게임이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
     E_404_Duplicated_Game_Session("E404008", "이미 저장된 게임이 존재합니다.", HttpStatus.NOT_FOUND),
+    E_404_PAGE_NOT_FOUND("E404009", "페이지 번호를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
 
     //409 Conflict

--- a/src/main/java/com/scriptopia/demo/repository/HistoryRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/HistoryRepository.java
@@ -14,6 +14,9 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("select h from History h where h.uuid = :uuid")
     Optional<History> findByUuid(@Param("uuid") UUID uuid);
 
+    @Query("select h.id from History h where h.user.id = : userId and h.uuid = :uuid")
+    Optional<Long> findByUserIdAndUuid(@Param("userId") Long userId, @Param("uuid") UUID uuid);
+
     Page<History> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
 
     Page<History> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);

--- a/src/main/java/com/scriptopia/demo/repository/HistoryRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/HistoryRepository.java
@@ -1,11 +1,18 @@
 package com.scriptopia.demo.repository;
 
 import com.scriptopia.demo.domain.History;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+import java.util.UUID;
 
 public interface HistoryRepository extends JpaRepository<History, Long> {
+    @Query("select h from History h where h.uuid = :uuid")
+    Optional<History> findByUuid(@Param("uuid") UUID uuid);
 
     Page<History> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);
 

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
@@ -10,13 +10,14 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface SharedGameRepository extends JpaRepository<SharedGame, Long> {
     @Query("select sg from SharedGame sg where sg.user.id = :userId")
     List<SharedGame> findAllByUserid(@Param("userId") Long userId);
 
-    @Query("select sg.id from SharedGame sg where sg.uuid = :uuid")
-    Long findByUuid(@Param("uuid") String uuid);
+    @Query("select sg from SharedGame sg where sg.uuid = :uuid")
+    Optional<SharedGame> findByUuid(@Param("uuid") UUID uuid);
 
     // 기본(전체)
     @Query("""

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -27,11 +28,11 @@ public class SharedGameService {
     private final TagDefRepository tagDefRepository;
 
     @Transactional
-    public ResponseEntity<?> saveSharedGame(Long Id, Long historyId) {
+    public ResponseEntity<?> saveSharedGame(Long Id, UUID uuid) {
         User user = userRepository.findById(Id)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
 
-        History history = historyRepository.findById(historyId)
+        History history = historyRepository.findByUuid(uuid)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND));
 
         if(!history.getUser().getId().equals(Id)) {
@@ -52,7 +53,7 @@ public class SharedGameService {
 
         for(SharedGame game : games) {
             MySharedGameResponse dto = new MySharedGameResponse();
-            dto.setUuid(game.getUuid().toString());
+            dto.setShared_game_uuid(game.getUuid());
             dto.setThumbnailUrl(game.getThumbnailUrl());
             dto.setTotalPlayed(sharedGameScoreRepository.countBySharedGameId(game.getId()));
             dto.setTitle(game.getTitle());
@@ -78,12 +79,12 @@ public class SharedGameService {
     }
 
     @Transactional
-    public void deletesharedGame(Long id, Long sharedId) {
+    public void deletesharedGame(Long id, UUID uuid) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
 
-        SharedGame game = sharedGameRepository.findById(sharedId)
-                .orElseThrow(() -> new CustomException(ErrorCode.E_404_SHARED_GAME_NOT_FOUND));
+        SharedGame game = sharedGameRepository.findByUuid(uuid)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND));
 
         if(!game.getUser().getId().equals(user.getId())) {        // 공유된 게임과 로그인한 사용자가 아닌 경우
             throw new CustomException(ErrorCode.E_401_NOT_EQUAL_SHARED_GAME);


### PR DESCRIPTION
## 🚀 관련 이슈

Close #133

## 📑 PR 설명
history uuid 생성

## ✏️ 작업 내용
무한스크롤 historyController 구현 service 수정, repository 수정

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 마이페이지 기록 조회에 무한 스크롤 지원: size 파라미터 추가, lastId가 UUID로 변경.
  - 공유/게임 세션 식별자를 UUID로 통일하여 더 안정적인 공유 링크 제공.
  - 마이페이지 관련 API 경로 단순화(/user 접두사 제거).
- Bug Fixes
  - 잘못된 페이지 번호 조회 시 명확한 404 오류 메시지 추가(“페이지 번호를 찾을 수 없습니다.”).
  - 사용자 인증 기반으로 내 기록/공유 내역을 정확히 로드하도록 안정성 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->