### PR TITLE
[Feature] 공유게임 UUID 필드 생성

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/MyPageController.java
+++ b/src/main/java/com/scriptopia/demo/controller/MyPageController.java
@@ -58,7 +58,7 @@ public class MyPageController {
     public ResponseEntity<?> delete(Authentication authentication, @PathVariable UUID uuid) {
         Long userId = Long.valueOf(authentication.getName());
 
-        sharedGameService.deletesharedGame(userId, uuid);
+        sharedGameService.deleteSharedGame(userId, uuid);
 
         return ResponseEntity.ok("게임이 삭제되었습니다.");
     }

--- a/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
@@ -9,23 +9,33 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
-@RequestMapping("/public/games/shared")
+@RequestMapping("/games/shared")
 @RequiredArgsConstructor
 public class PublicSharedGameController {
     private final SharedGameService sharedGameService;
 
-    @GetMapping("/{sharedGameId}")
-    public ResponseEntity<?> getSharedGameDetail(@PathVariable Long sharedGameId) {
-        return sharedGameService.getDetailedSharedGame(sharedGameId);
+    /*
+    게임공유 : 공유된 게임 상세 조회
+     */
+    @GetMapping("/{uuid}")
+    public ResponseEntity<?> getSharedGameDetail(@PathVariable UUID uuid) {
+        return sharedGameService.getDetailedSharedGame(uuid);
     }
 
+    /*
+    게임공유 : 공유된 게임 태그 조회
+     */
     @GetMapping("/tags")
     public ResponseEntity<?> getSharedGameTags() {
         return sharedGameService.getTag();
     }
 
+    /*
+    게임공유 : 공유된 게임 목록 조회
+     */
     @GetMapping
     public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
                                                                                      @RequestParam(required = false) Long lastId,

--- a/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PublicSharedGameController.java
@@ -41,8 +41,8 @@ public class PublicSharedGameController {
                                                                                      @RequestParam(required = false) Long lastId,
                                                                                      @RequestParam(defaultValue = "20") int size,
                                                                                      @RequestParam(required = false) List<Long> tagIds,
-                                                                                     @RequestParam(required = false) String q) {
+                                                                                     @RequestParam(required = false) String query) {
         Long viewerId = (authentication == null) ? null : Long.valueOf(authentication.getName());
-        return sharedGameService.getPublicSharedGames(viewerId, lastId, size, tagIds, q);
+        return sharedGameService.getPublicSharedGames(viewerId, lastId, size, tagIds, query);
     }
 }

--- a/src/main/java/com/scriptopia/demo/domain/SharedGame.java
+++ b/src/main/java/com/scriptopia/demo/domain/SharedGame.java
@@ -45,6 +45,10 @@ public class SharedGame {
         if(uuid == null) {
             uuid = UUID.randomUUID();
         }
+
+        if(sharedAt == null) {
+            sharedAt = LocalDateTime.now();
+        }
     }
 
     public static SharedGame from(User user, History h) {

--- a/src/main/java/com/scriptopia/demo/dto/history/HistoryPageResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/history/HistoryPageResponse.java
@@ -4,10 +4,11 @@ import com.scriptopia.demo.domain.History;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 public class HistoryPageResponse {
-    private Long id;
+    private UUID uuid;
     private String title;
     private Long score;
     private String thumbnail_url;
@@ -15,7 +16,7 @@ public class HistoryPageResponse {
 
     public static HistoryPageResponse from(History h) {
         HistoryPageResponse dto = new HistoryPageResponse();
-        dto.setId(h.getId());
+        dto.setUuid(h.getUuid());
         dto.setTitle(h.getTitle());
         dto.setScore(h.getScore());
         dto.setThumbnail_url(h.getThumbnailUrl());

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
@@ -5,10 +5,11 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 public class PublicSharedGameDetailResponse {
-    private Long sharedGameId;
+    private UUID sharedGameUUID;
     private String nickname;
     private String thumbnailUrl;
     private Long totalPlayed;

--- a/src/main/java/com/scriptopia/demo/repository/HistoryRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/HistoryRepository.java
@@ -14,7 +14,7 @@ public interface HistoryRepository extends JpaRepository<History, Long> {
     @Query("select h from History h where h.uuid = :uuid")
     Optional<History> findByUuid(@Param("uuid") UUID uuid);
 
-    @Query("select h.id from History h where h.user.id = : userId and h.uuid = :uuid")
+    @Query("select h.id from History h where h.user.id = :userId and h.uuid = :uuid")
     Optional<Long> findByUserIdAndUuid(@Param("userId") Long userId, @Param("uuid") UUID uuid);
 
     Page<History> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long lastId, Pageable pageable);

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -79,7 +79,7 @@ public class SharedGameService {
     }
 
     @Transactional
-    public void deletesharedGame(Long id, UUID uuid) {
+    public void deleteSharedGame(Long id, UUID uuid) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
 
@@ -93,8 +93,8 @@ public class SharedGameService {
         sharedGameRepository.delete(game);
     }
 
-    public ResponseEntity<?> getDetailedSharedGame(Long sharedId) {
-        SharedGame game = sharedGameRepository.findById(sharedId)
+    public ResponseEntity<?> getDetailedSharedGame(UUID uuid) {
+        SharedGame game = sharedGameRepository.findByUuid(uuid)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_SHARED_GAME_NOT_FOUND));
 
         List<String> tagName = gameTagRepository.findTagNamesBySharedGameId(game.getId());
@@ -102,7 +102,7 @@ public class SharedGameService {
         List<SharedGameScore> score = sharedGameScoreRepository.findAllBySharedGameIdOrderByScoreDescCreatedAtDesc(game.getId());
 
         PublicSharedGameDetailResponse dto = new PublicSharedGameDetailResponse();
-        dto.setSharedGameId(game.getId());
+        dto.setSharedGameUUID(game.getUuid());
         dto.setNickname(game.getUser().getNickname());
         dto.setThumbnailUrl(game.getThumbnailUrl());
         dto.setTotalPlayed(game.getTotalPlayed());


### PR DESCRIPTION
## 🚀 관련 이슈

Close #126 

## 📑 PR 설명
공유된 게임 repository 수정

## ✏️ 작업 내용
repository 전반적으로 수정

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능: 없음
- 리팩터링
  - 공개 공유 게임 API를 UUID 기반으로 전환: 상세 조회 경로 변수 ID → UUID
  - 기본 경로 변경: /public/games/shared → /games/shared
  - 목록 검색 파라미터명 변경: q → query
  - 응답 필드 정비: History id → uuid, SharedGame sharedGameId → sharedGameUUID
  - 공유 시각(sharedAt) 자동 설정으로 일관된 타임스탬프 제공
- 버그 수정
  - 잘못된 파라미터 바인딩을 수정해 조회 안정성 향상
- 문서
  - 엔드포인트 주석 보강으로 가독성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->