### PR TITLE
Feature/128 user settings

### DIFF
--- a/src/main/java/com/scriptopia/demo/config/AdminInitializer.java
+++ b/src/main/java/com/scriptopia/demo/config/AdminInitializer.java
@@ -3,6 +3,7 @@ package com.scriptopia.demo.config;
 import com.scriptopia.demo.domain.*;
 import com.scriptopia.demo.repository.LocalAccountRepository;
 import com.scriptopia.demo.repository.UserRepository;
+import com.scriptopia.demo.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
@@ -22,6 +23,7 @@ public class AdminInitializer implements ApplicationRunner {
     private final UserRepository userRepository;
     private final LocalAccountRepository localAccountRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserSettingRepository userSettingRepository;
 
     @Value("${app.admin.username}")
     private String adminUsername;
@@ -44,7 +46,6 @@ public class AdminInitializer implements ApplicationRunner {
             admin.setProfileImgUrl(null);
             admin.setRole(Role.ADMIN);
             admin.setLoginType(LoginType.LOCAL);
-
             User adminUser = userRepository.save(admin);
 
 
@@ -54,9 +55,17 @@ public class AdminInitializer implements ApplicationRunner {
             localAccount.setPassword(passwordEncoder.encode(adminPassword));
             localAccount.setUpdatedAt(LocalDateTime.now());
             localAccount.setStatus(UserStatus.VERIFIED);
-
             LocalAccount adminAccount = localAccountRepository.save(localAccount);
 
+            UserSetting userSetting = new UserSetting();
+            userSetting.setUser(adminUser);
+            userSetting.setTheme(Theme.DARK);
+            userSetting.setFontType(FontType.PretendardVariable);
+            userSetting.setFontSize(16);
+            userSetting.setLineHeight(1);
+            userSetting.setWordSpacing(1);
+            userSetting.setUpdatedAt(LocalDateTime.now());
+            userSettingRepository.save(userSetting);
 
         }
     }

--- a/src/main/java/com/scriptopia/demo/controller/AuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuthController.java
@@ -1,16 +1,13 @@
 package com.scriptopia.demo.controller;
 
-import com.scriptopia.demo.config.JwtProperties;
 import com.scriptopia.demo.dto.localaccount.*;
 import com.scriptopia.demo.service.LocalAccountService;
-import com.scriptopia.demo.utils.JwtProvider;
 import com.scriptopia.demo.service.RefreshTokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/games/shared")
 @RequiredArgsConstructor
-public class PublicSharedGameController {
+public class SharedGameController {
     private final SharedGameService sharedGameService;
 
     /*

--- a/src/main/java/com/scriptopia/demo/controller/UserController.java
+++ b/src/main/java/com/scriptopia/demo/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.scriptopia.demo.controller;
+
+import com.scriptopia.demo.dto.users.GetSettingsResponse;
+import com.scriptopia.demo.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users/me")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
+    @GetMapping("/settings")
+    public ResponseEntity<GetSettingsResponse> getUserSettings(
+            Authentication authentication
+    ) {
+        String userId = authentication.getName();
+        GetSettingsResponse response = userService.getUserSettings(userId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/scriptopia/demo/domain/UserSetting.java
+++ b/src/main/java/com/scriptopia/demo/domain/UserSetting.java
@@ -25,5 +25,7 @@ public class UserSetting {
 
     private int lineHeight;
 
+    private int wordSpacing;
+
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/scriptopia/demo/dto/users/GetSettingsResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/users/GetSettingsResponse.java
@@ -1,0 +1,20 @@
+package com.scriptopia.demo.dto.users;
+
+import com.scriptopia.demo.domain.FontType;
+import com.scriptopia.demo.domain.Theme;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class GetSettingsResponse {
+    private Theme theme;
+    private Integer fondSize;
+    private FontType font;
+    private Integer lineHeight;
+    private Integer wordSpacing;
+}

--- a/src/main/java/com/scriptopia/demo/repository/UserSettingRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/UserSettingRepository.java
@@ -4,4 +4,6 @@ import com.scriptopia.demo.domain.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
+
+    UserSetting findByUserId(Long userId);
 }

--- a/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
+++ b/src/main/java/com/scriptopia/demo/service/LocalAccountService.java
@@ -7,6 +7,7 @@ import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.LocalAccountRepository;
 import com.scriptopia.demo.repository.UserRepository;
+import com.scriptopia.demo.repository.UserSettingRepository;
 import com.scriptopia.demo.utils.JwtProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -50,7 +51,7 @@ public class LocalAccountService {
     private static final Pattern WS = Pattern.compile("[\\s\\p{Z}\\u200B\\u200C\\u200D\\uFEFF]");
 
     private static final long TOKEN_EXPIRATION = 30;
-
+    private final UserSettingRepository userSettingRepository;
 
 
     @Transactional
@@ -168,11 +169,14 @@ public class LocalAccountService {
 
         //환경 설정 초기 값
         UserSetting userSetting = new UserSetting();
+        userSetting.setUser(user);
         userSetting.setTheme(Theme.DARK);
         userSetting.setFontType(FontType.PretendardVariable);
         userSetting.setFontSize(16);
         userSetting.setLineHeight(1);
+        userSetting.setWordSpacing(1);
         userSetting.setUpdatedAt(LocalDateTime.now());
+        userSettingRepository.save(userSetting);
 
     }
 

--- a/src/main/java/com/scriptopia/demo/service/UserService.java
+++ b/src/main/java/com/scriptopia/demo/service/UserService.java
@@ -1,9 +1,7 @@
 package com.scriptopia.demo.service;
 
-import com.scriptopia.demo.domain.User;
 import com.scriptopia.demo.domain.UserSetting;
 import com.scriptopia.demo.dto.users.GetSettingsResponse;
-import com.scriptopia.demo.repository.UserRepository;
 import com.scriptopia.demo.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +15,7 @@ public class UserService {
     private final UserSettingRepository userSettingRepository;
 
     @Transactional
-    public GetSettingsResponse getSettings(String userId){
+    public GetSettingsResponse getUserSettings(String userId){
 
         UserSetting userSetting = userSettingRepository.findByUserId(Long.valueOf(userId));
 

--- a/src/main/java/com/scriptopia/demo/service/UserService.java
+++ b/src/main/java/com/scriptopia/demo/service/UserService.java
@@ -1,0 +1,34 @@
+package com.scriptopia.demo.service;
+
+import com.scriptopia.demo.domain.User;
+import com.scriptopia.demo.domain.UserSetting;
+import com.scriptopia.demo.dto.users.GetSettingsResponse;
+import com.scriptopia.demo.repository.UserRepository;
+import com.scriptopia.demo.repository.UserSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserSettingRepository userSettingRepository;
+
+    @Transactional
+    public GetSettingsResponse getSettings(String userId){
+
+        UserSetting userSetting = userSettingRepository.findByUserId(Long.valueOf(userId));
+
+        return GetSettingsResponse.builder()
+                .theme(userSetting.getTheme())
+                .fondSize(userSetting.getFontSize())
+                .font(userSetting.getFontType())
+                .lineHeight(userSetting.getLineHeight())
+                .wordSpacing(userSetting.getWordSpacing())
+                .build();
+
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true


### PR DESCRIPTION
## 🚀 관련 이슈

Close #128 

## 📑 PR 설명
사용자 개인의 옵션을 조회한다.

## ✏️ 작업 내용
1. 사용자 조회 API 구현
## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 빌드 통과 확인
- [x] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 내 정보 페이지에서 내 사용자 설정 조회 엔드포인트 추가(/users/me/settings).
  * 새 계정 및 관리자 계정에 기본 사용자 설정 자동 생성(테마, 폰트, 글자 크기, 줄 간격, 단어 간격 포함).
  * 사용자 설정에 단어 간격 옵션 추가.
* Refactor
  * 공유 게임 컨트롤러 이름 정리(동작 변화 없음).
* Chores
  * 불필요한 임포트 정리(동작 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->