### PR TITLE
[Feature] 인증 변경에 따른 게임세션 인증 추가

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -20,7 +20,10 @@ public class GameSessionController {
     private final GameSessionService gameSessionService;
     private final HistoryService historyService;
 
-    @PreAuthorize("hasAnyAuthority('USER')")
+    /*
+    게임 -> 게임 도중 종료
+     */
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("/{gameId}/exit")
     public ResponseEntity<?> createGameSession(Authentication authentication, @PathVariable String gameId) {
         // 게임 세션 정보 저장
@@ -29,7 +32,10 @@ public class GameSessionController {
         return gameSessionService.saveGameSession(userId, gameId);
     }
 
-    @PreAuthorize("hasAnyAuthority('USER')")
+    /*
+    게임 -> 기존 게임 삭제
+     */
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @DeleteMapping("/{gameId}")
     public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String sessionId) {
         Long userId = Long.valueOf(authentication.getName());
@@ -67,8 +73,7 @@ public class GameSessionController {
      * 현재는 userId, sessionId를 통해 저장하는데
      * 인증 관리 부분 끝나면 header에 token 꺼내오고 requestparameter session_id로 저장하게 수정
      */
-    @PreAuthorize("hasAnyAuthority('USER')")
-    @PostMapping("/{gameId}/history")
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     public ResponseEntity<?> addHistory(@PathVariable String gameId, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 

--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/users/games")
+@RequestMapping("/games")
 @RequiredArgsConstructor
 public class GameSessionController {
     private final GameSessionService gameSessionService;
@@ -61,6 +61,14 @@ public class GameSessionController {
 
         GameSessionMongo response = gameSessionService.mapToCreateGameChoiceRequest(userId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentGame(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+
+
+
     }
 
     /**

--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -63,14 +63,6 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/me")
-    public ResponseEntity<?> getCurrentGame(Authentication authentication) {
-        Long userId = Long.valueOf(authentication.getName());
-
-
-
-    }
-
     /**
      * 현재는 userId, sessionId를 통해 저장하는데
      * 인증 관리 부분 끝나면 header에 token 꺼내오고 requestparameter session_id로 저장하게 수정

--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -25,7 +25,7 @@ public class GameSessionController {
      */
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("/{gameId}/exit")
-    public ResponseEntity<?> createGameSession(Authentication authentication, @PathVariable String gameId) {
+    public ResponseEntity<?> createGameSession(Authentication authentication, @PathVariable("gameId") String gameId) {
         // 게임 세션 정보 저장
         Long userId = Long.valueOf(authentication.getName());
 
@@ -37,12 +37,12 @@ public class GameSessionController {
      */
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @DeleteMapping("/{gameId}")
-    public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String sessionId) {
+    public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable("gameId") String gameId) {
         Long userId = Long.valueOf(authentication.getName());
 
-        return gameSessionService.deleteGameSession(userId, sessionId);
+        return gameSessionService.deleteGameSession(userId, gameId);
     }
-    
+
     
     // 게임 시작
     @PostMapping
@@ -69,12 +69,26 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
+    /*
+    게임 -> 기존 게임 조회
+     */
+    @GetMapping("/me")
+    public ResponseEntity<?> loadGameSession(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return gameSessionService.getGameSession(userId);
+    }
+
     /**
      * 현재는 userId, sessionId를 통해 저장하는데
      * 인증 관리 부분 끝나면 header에 token 꺼내오고 requestparameter session_id로 저장하게 수정
      */
+    /*
+    게임 -> 히스토리 생성
+     */
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
-    public ResponseEntity<?> addHistory(@PathVariable String gameId, Authentication authentication) {
+    @PostMapping("/{gameId}/history")
+    public ResponseEntity<?> addHistory(@PathVariable("gameId") String gameId, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 
         return historyService.createHistory(userId, gameId);

--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -9,6 +9,7 @@ import com.scriptopia.demo.service.GameSessionService;
 import com.scriptopia.demo.service.HistoryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +20,7 @@ public class GameSessionController {
     private final GameSessionService gameSessionService;
     private final HistoryService historyService;
 
+    @PreAuthorize("hasAnyAuthority('USER')")
     @PostMapping("/{gameId}/exit")
     public ResponseEntity<?> createGameSession(Authentication authentication, @PathVariable String gameId) {
         // 게임 세션 정보 저장
@@ -27,6 +29,7 @@ public class GameSessionController {
         return gameSessionService.saveGameSession(userId, gameId);
     }
 
+    @PreAuthorize("hasAnyAuthority('USER')")
     @DeleteMapping("/{gameId}")
     public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String sessionId) {
         Long userId = Long.valueOf(authentication.getName());
@@ -64,6 +67,7 @@ public class GameSessionController {
      * 현재는 userId, sessionId를 통해 저장하는데
      * 인증 관리 부분 끝나면 header에 token 꺼내오고 requestparameter session_id로 저장하게 수정
      */
+    @PreAuthorize("hasAnyAuthority('USER')")
     @PostMapping("/{gameId}/history")
     public ResponseEntity<?> addHistory(@PathVariable String gameId, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());

--- a/src/main/java/com/scriptopia/demo/controller/MyPageController.java
+++ b/src/main/java/com/scriptopia/demo/controller/MyPageController.java
@@ -19,8 +19,19 @@ public class MyPageController {
     private final SharedGameService sharedGameService;
     private final GameSessionService gameSessionService;
 
+
     /*
-    계정관리 : 내 히스토리 조회 -> 무한스크롤
+    게임 공유 -> 게임 공유하기
+     */
+    @PostMapping("/my-page/share/{uuid}")
+    public ResponseEntity<?> share(Authentication authentication, @PathVariable UUID uuid) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return sharedGameService.saveSharedGame(userId, uuid);
+    }
+
+    /*
+    유저 -> 사용자 게임 기록 조회
      */
     @GetMapping("/my-page/history")
     public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) UUID lastId,
@@ -32,7 +43,7 @@ public class MyPageController {
     }
 
     /*
-    계정관리 : 내가 공유한 게임 조회
+    게임 공유 -> 공유한 게임 조회(내가 공유한 게임 조회)
      */
     @GetMapping("/my-page/games/shared")
     public ResponseEntity<?> getMySharedGames(Authentication authentication) {
@@ -41,18 +52,9 @@ public class MyPageController {
         return sharedGameService.getMySharedGames(userId);
     }
 
-    /*
-    계정관리 : 내 히스토리 공유하기
-     */
-    @PostMapping("/my-page/share/{uuid}")
-    public ResponseEntity<?> share(Authentication authentication, @PathVariable UUID uuid) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        return sharedGameService.saveSharedGame(userId, uuid);
-    }
 
     /*
-    계정관리 : 내가 공유한 게임 삭제
+    게임 공유 -> 공유한 게임 삭제
      */
     @DeleteMapping("/my-page/share/{uuid}")
     public ResponseEntity<?> delete(Authentication authentication, @PathVariable UUID uuid) {
@@ -64,22 +66,12 @@ public class MyPageController {
     }
 
     /*
-    계정관리 : 게임 세션(이어하기) 조회
+    게임 -> 기존 게임 조회
      */
     @GetMapping("/my-page/game")
     public ResponseEntity<?> loadGameSession(Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 
         return gameSessionService.getGameSession(userId);
-    }
-
-    /*
-    계정관리 : 게임 세션(이어하기) 삭제
-     */
-    @DeleteMapping("/my-page/game/{gameId}")
-    public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String gameId) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        return gameSessionService.deleteGameSession(userId, gameId);
     }
 }

--- a/src/main/java/com/scriptopia/demo/controller/MyPageController.java
+++ b/src/main/java/com/scriptopia/demo/controller/MyPageController.java
@@ -21,16 +21,6 @@ public class MyPageController {
 
 
     /*
-    게임 공유 -> 게임 공유하기
-     */
-    @PostMapping("/my-page/share/{uuid}")
-    public ResponseEntity<?> share(Authentication authentication, @PathVariable UUID uuid) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        return sharedGameService.saveSharedGame(userId, uuid);
-    }
-
-    /*
     유저 -> 사용자 게임 기록 조회
      */
     @GetMapping("/my-page/history")
@@ -42,28 +32,6 @@ public class MyPageController {
         return historyService.fetchMyHistory(userId, lastId, size);
     }
 
-    /*
-    게임 공유 -> 공유한 게임 조회(내가 공유한 게임 조회)
-     */
-    @GetMapping("/my-page/games/shared")
-    public ResponseEntity<?> getMySharedGames(Authentication authentication) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        return sharedGameService.getMySharedGames(userId);
-    }
-
-
-    /*
-    게임 공유 -> 공유한 게임 삭제
-     */
-    @DeleteMapping("/my-page/share/{uuid}")
-    public ResponseEntity<?> delete(Authentication authentication, @PathVariable UUID uuid) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        sharedGameService.deleteSharedGame(userId, uuid);
-
-        return ResponseEntity.ok("게임이 삭제되었습니다.");
-    }
 
     /*
     게임 -> 기존 게임 조회
@@ -73,5 +41,15 @@ public class MyPageController {
         Long userId = Long.valueOf(authentication.getName());
 
         return gameSessionService.getGameSession(userId);
+    }
+
+    /*
+    게임 -> 기존 게임 삭제
+     */
+    @DeleteMapping("/my-page/game/{gameId}")
+    public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String gameId) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return gameSessionService.deleteGameSession(userId, gameId);
     }
 }

--- a/src/main/java/com/scriptopia/demo/controller/MyPageController.java
+++ b/src/main/java/com/scriptopia/demo/controller/MyPageController.java
@@ -32,24 +32,4 @@ public class MyPageController {
         return historyService.fetchMyHistory(userId, lastId, size);
     }
 
-
-    /*
-    게임 -> 기존 게임 조회
-     */
-    @GetMapping("/my-page/game")
-    public ResponseEntity<?> loadGameSession(Authentication authentication) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        return gameSessionService.getGameSession(userId);
-    }
-
-    /*
-    게임 -> 기존 게임 삭제
-     */
-    @DeleteMapping("/my-page/game/{gameId}")
-    public ResponseEntity<?> deleteGameSession(Authentication authentication, @PathVariable String gameId) {
-        Long userId = Long.valueOf(authentication.getName());
-
-        return gameSessionService.deleteGameSession(userId, gameId);
-    }
 }

--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -7,6 +7,7 @@ import com.scriptopia.demo.service.SharedGameFavoriteService;
 import com.scriptopia.demo.service.SharedGameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +24,7 @@ public class SharedGameController {
     /*
     게임 공유 -> 게임 공유하기
      */
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping
     public ResponseEntity<?> share(Authentication authentication, @PathVariable UUID uuid) {
         Long userId = Long.valueOf(authentication.getName());
@@ -54,6 +56,7 @@ public class SharedGameController {
     /*
     게임공유 : 공유 게임 Like 요청
      */
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("{sharedGameId}/like")
     public ResponseEntity<?> likeSharedGame(@PathVariable Long sharedGameId, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
@@ -64,6 +67,7 @@ public class SharedGameController {
     /*
     게임공유 : 공유된 게임 태그 조회
      */
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @GetMapping("/tags")
     public ResponseEntity<?> getSharedGameTags() {
         return sharedGameService.getTag();
@@ -72,6 +76,7 @@ public class SharedGameController {
     /*
     게임 공유 -> 공유한 게임 삭제
      */
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @DeleteMapping("/shared-games")
     public ResponseEntity<?> delete(Authentication authentication, @PathVariable UUID uuid) {
         Long userId = Long.valueOf(authentication.getName());
@@ -84,6 +89,7 @@ public class SharedGameController {
     /*
     게임 공유 -> 공유한 게임 조회(내가 공유한 게임 조회)
      */
+    @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @GetMapping("/me")
     public ResponseEntity<?> getMySharedGames(Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());

--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -1,7 +1,9 @@
 package com.scriptopia.demo.controller;
 
+import com.scriptopia.demo.domain.SharedGameFavorite;
 import com.scriptopia.demo.dto.sharedgame.CursorPage;
 import com.scriptopia.demo.dto.sharedgame.PublicSharedGameResponse;
+import com.scriptopia.demo.service.SharedGameFavoriteService;
 import com.scriptopia.demo.service.SharedGameService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,17 +14,51 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/games/shared")
+@RequestMapping("shared-games")
 @RequiredArgsConstructor
 public class SharedGameController {
     private final SharedGameService sharedGameService;
+    private final SharedGameFavoriteService sharedGameFavoriteService;
+
+    /*
+    게임 공유 -> 게임 공유하기
+     */
+    @PostMapping
+    public ResponseEntity<?> share(Authentication authentication, @PathVariable UUID uuid) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return sharedGameService.saveSharedGame(userId, uuid);
+    }
+
+    /*
+    게임 공유 -> 공유 게임 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
+                                                                                     @RequestParam(required = false) Long lastId,
+                                                                                     @RequestParam(defaultValue = "20") int size,
+                                                                                     @RequestParam(required = false) List<Long> tagIds,
+                                                                                     @RequestParam(required = false) String query) {
+        Long viewerId = (authentication == null) ? null : Long.valueOf(authentication.getName());
+        return sharedGameService.getPublicSharedGames(viewerId, lastId, size, tagIds, query);
+    }
 
     /*
     게임공유 : 공유된 게임 상세 조회
      */
-    @GetMapping("/{uuid}")
-    public ResponseEntity<?> getSharedGameDetail(@PathVariable UUID uuid) {
-        return sharedGameService.getDetailedSharedGame(uuid);
+    @GetMapping("{sharedGameId}")
+    public ResponseEntity<?> getSharedGameDetail(@PathVariable("sharedGameId") UUID sharedGameId) {
+        return sharedGameService.getDetailedSharedGame(sharedGameId);
+    }
+
+    /*
+    게임공유 : 공유 게임 Like 요청
+     */
+    @PostMapping("{sharedGameId}/like")
+    public ResponseEntity<?> likeSharedGame(@PathVariable Long sharedGameId, Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return sharedGameFavoriteService.saveFavorite(userId, sharedGameId);
     }
 
     /*
@@ -34,15 +70,24 @@ public class SharedGameController {
     }
 
     /*
-    게임공유 : 공유된 게임 목록 조회
+    게임 공유 -> 공유한 게임 삭제
      */
-    @GetMapping
-    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
-                                                                                     @RequestParam(required = false) Long lastId,
-                                                                                     @RequestParam(defaultValue = "20") int size,
-                                                                                     @RequestParam(required = false) List<Long> tagIds,
-                                                                                     @RequestParam(required = false) String query) {
-        Long viewerId = (authentication == null) ? null : Long.valueOf(authentication.getName());
-        return sharedGameService.getPublicSharedGames(viewerId, lastId, size, tagIds, query);
+    @DeleteMapping("/shared-games")
+    public ResponseEntity<?> delete(Authentication authentication, @PathVariable UUID uuid) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        sharedGameService.deleteSharedGame(userId, uuid);
+
+        return ResponseEntity.ok("게임이 삭제되었습니다.");
+    }
+
+    /*
+    게임 공유 -> 공유한 게임 조회(내가 공유한 게임 조회)
+     */
+    @GetMapping("/me")
+    public ResponseEntity<?> getMySharedGames(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        return sharedGameService.getMySharedGames(userId);
     }
 }

--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/games/shared")
 @RequiredArgsConstructor
-public class PublicSharedGameController {
+public class SharedGameController {
     private final SharedGameService sharedGameService;
 
     /*

--- a/src/main/java/com/scriptopia/demo/controller/TagDefController.java
+++ b/src/main/java/com/scriptopia/demo/controller/TagDefController.java
@@ -5,14 +5,16 @@ import com.scriptopia.demo.dto.TagDef.TagDefDeleteRequest;
 import com.scriptopia.demo.service.TagDefService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-@RestController("/admin/tag")
+@RestController("/shared-games/tags")
 @RequiredArgsConstructor
 public class TagDefController {
     private final TagDefService tagDefService;
 
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     @PostMapping
     public ResponseEntity<?> addTag(@RequestBody TagDefCreateRequest req, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
@@ -20,6 +22,7 @@ public class TagDefController {
         return tagDefService.addTagName(req, userId);
     }
 
+    @PreAuthorize("hasAnyAuthority('ADMIN')")
     @DeleteMapping
     public ResponseEntity<?> removeTag(@RequestBody TagDefDeleteRequest req, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -39,18 +39,6 @@ public class GameSessionService {
     private final MongoClient mongo;
     private final WebInvocationPrivilegeEvaluator privilegeEvaluator;
 
-    public boolean duplcatedGameSession(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
-
-        boolean game = gameSessionRepository.existsByUserId(user.getId());
-
-        if(game) {
-            return true;
-        }
-        else return false;
-    }
-
     public ResponseEntity<?> getGameSession(Long userid) {
         User user = userRepository.findById(userid)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));

--- a/src/main/java/com/scriptopia/demo/service/HistoryService.java
+++ b/src/main/java/com/scriptopia/demo/service/HistoryService.java
@@ -90,13 +90,6 @@ public class HistoryService {
         return ResponseEntity.ok(saved.getObjectId("_id").toHexString());
     }
 
-    public ResponseEntity<?> getHistory(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
-
-
-    }
-
     private HistoryRequest mapMongoToHistoryRequest(Document doc) {
         JsonNode root = asJson(doc);
         JsonNode hi   = root.path("history_info");

--- a/src/main/java/com/scriptopia/demo/service/HistoryService.java
+++ b/src/main/java/com/scriptopia/demo/service/HistoryService.java
@@ -90,6 +90,13 @@ public class HistoryService {
         return ResponseEntity.ok(saved.getObjectId("_id").toHexString());
     }
 
+    public ResponseEntity<?> getHistory(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
+
+
+    }
+
     private HistoryRequest mapMongoToHistoryRequest(Document doc) {
         JsonNode root = asJson(doc);
         JsonNode hi   = root.path("history_info");
@@ -146,4 +153,5 @@ public class HistoryService {
 
         return ResponseEntity.ok(page.getContent().stream().map(HistoryPageResponse::from).toList());
     }
+
 }


### PR DESCRIPTION
## 🚀 관련 이슈

Close #143 

## 📑 PR 설명

## ✏️ 작업 내용
공유게임, 게임 세션, 사용자 등 컨트롤러 기능 분리, 어노테이션 추가

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 공유 게임 좋아요 추가, 내 공유 게임 목록 조회, 공유 생성(POST) 및 상세 조회 개선.
  - 내 게임 세션 조회(/games/me) 및 히스토리 추가 엔드포인트 제공.  
- 변경
  - 공유 게임 기본 경로를 /shared-games 로 통합; 태그 경로를 /shared-games/tags 로 이동.
  - 마이페이지 히스토리 조회에 size 파라미터 추가(무한스크롤 개선).  
- 보안
  - 태그 관리 엔드포인트를 ADMIN 전용으로 제한.
  - 일부 게임 시작/시드 엔드포인트의 접근 제한 완화.  
- 제거
  - 마이페이지 공유/게임 관련 다수 엔드포인트 정리 및 통합.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->