### PR TITLE
Feature/game entry start continue 146

### DIFF
--- a/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameDoneResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameDoneResponse.java
@@ -22,7 +22,24 @@ public class InGameDoneResponse {
     private int progress;
     private int stageSize;
 
-    private InGamePlayerResponse playerInfo; // 외부
-    private InGameNpcResponse npcInfo; // 외부
-    private List<InGameInventoryResponse> inventory; // 외부
+    private InGamePlayerResponse playerInfo;
+    private InGameNpcResponse npcInfo;
+    private List<InGameInventoryResponse> inventory;
+
+    // 🏆 보상 정보
+    private RewardInfoResponse rewardInfo;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RewardInfoResponse {
+        private List<String> gainedItemNames;
+        private int rewardStrength;
+        private int rewardAgility;
+        private int rewardIntelligence;
+        private int rewardLuck;
+        private int rewardLife;
+        private int rewardGold;
+    }
 }

--- a/src/main/java/com/scriptopia/demo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/scriptopia/demo/exception/GlobalExceptionHandler.java
@@ -63,11 +63,11 @@ public class GlobalExceptionHandler {
     }
 
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
-
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponse(ErrorCode.E_500));
-    }
+//    @ExceptionHandler(Exception.class)
+//    public ResponseEntity<ErrorResponse> handleGeneralException(Exception ex) {
+//
+//        return ResponseEntity
+//                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+//                .body(new ErrorResponse(ErrorCode.E_500));
+//    }
 }

--- a/src/main/java/com/scriptopia/demo/mapper/InGameMapper.java
+++ b/src/main/java/com/scriptopia/demo/mapper/InGameMapper.java
@@ -104,4 +104,7 @@ public class InGameMapper {
                         .build())
                 .toList();
     }
+
+
+
 }

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -3,6 +3,7 @@ package com.scriptopia.demo.service;
 import com.scriptopia.demo.config.fastapi.FastApiClient;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameBattleResponse;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameChoiceResponse;
+import com.scriptopia.demo.dto.gamesession.ingame.InGameDoneResponse;
 import com.scriptopia.demo.dto.items.ItemDefRequest;
 import com.scriptopia.demo.dto.items.ItemFastApiResponse;
 import com.scriptopia.demo.mapper.InGameMapper;
@@ -297,6 +298,42 @@ public class GameSessionService {
                     .build();
 
         } else if (currentSceneType == SceneType.DONE) {
+
+            RewardInfoMongo rewardInfo = gameSessionMongo.getRewardInfo();
+
+            List<String> gainedItemNames = List.of();
+            if (rewardInfo != null && rewardInfo.getGainedItemDefId() != null) {
+                gainedItemNames = rewardInfo.getGainedItemDefId().stream()
+                        .map(itemDefId -> itemDefMongoRepository.findById(itemDefId)
+                                .map(ItemDefMongo::getName)
+                                .orElse("Unknown Item"))
+                        .toList();
+            }
+
+
+            return InGameDoneResponse.builder()
+                    .sceneType("DONE")
+                    .startedAt(gameSessionMongo.getStartedAt())
+                    .updatedAt(gameSessionMongo.getUpdatedAt())
+                    .background(gameSessionMongo.getBackground())
+                    .location(gameSessionMongo.getLocation())
+                    .progress(gameSessionMongo.getProgress())
+                    .stageSize(gameSessionMongo.getStage() != null ? gameSessionMongo.getStage().size() : 0)
+                    .playerInfo(inGameMapper.mapPlayer(gameSessionMongo.getPlayerInfo()))
+                    .npcInfo(inGameMapper.mapNpc(gameSessionMongo.getNpcInfo()))
+                    .inventory(inGameMapper.mapInventory(gameSessionMongo.getInventory()))
+                    .rewardInfo(
+                            InGameDoneResponse.RewardInfoResponse.builder()
+                                    .gainedItemNames(gainedItemNames)
+                                    .rewardStrength(rewardInfo != null && rewardInfo.getRewardStrength() != null ? rewardInfo.getRewardStrength() : 0)
+                                    .rewardAgility(rewardInfo != null && rewardInfo.getRewardAgility() != null ? rewardInfo.getRewardAgility() : 0)
+                                    .rewardIntelligence(rewardInfo != null && rewardInfo.getRewardIntelligence() != null ? rewardInfo.getRewardIntelligence() : 0)
+                                    .rewardLuck(rewardInfo != null && rewardInfo.getRewardLuck() != null ? rewardInfo.getRewardLuck() : 0)
+                                    .rewardLife(rewardInfo != null && rewardInfo.getRewardLife() != null ? rewardInfo.getRewardLife() : 0)
+                                    .rewardGold(rewardInfo != null && rewardInfo.getRewardGold() != null ? rewardInfo.getRewardGold() : 0)
+                                    .build()
+                    )
+                    .build();
 
 
         } else if (currentSceneType == SceneType.SHOP) {

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -1,6 +1,5 @@
 package com.scriptopia.demo.service;
 
-import com.scriptopia.demo.config.fastapi.FastApiClient;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameBattleResponse;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameChoiceResponse;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameDoneResponse;


### PR DESCRIPTION
## 📑 기능 설명  
사용자가 이전에 진행 중이던 게임을 이어서 플레이할 수 있는 API입니다.  
게임 ID와 플레이어 정보를 기반으로 현재 게임 상태를 불러와 진행 가능한 상태로 제공합니다.  

## ✅ 작업할 내용  
- [x] GET /games/{gameId} 엔드포인트 생성  ( 지금은 1:1이지만 확장성을 위해 )
- [x] path 변수로 gameId 전달  
- [x] 게임 존재 여부 및 플레이어 권한 확인  
- [x] 현재 게임 상태(캐릭터 상태, 진행 이벤트, 아이템, 위치 등) 조회  
- [x] 성공/에러 응답 포맷 적용  

## 🎈 기대 효과  
- 사용자가 중단한 게임을 이어서 플레이 가능  
- 게임 몰입도 유지 및 플레이어 경험 향상  
- 진행 중인 이벤트 및 상태가 정확히 반영되어 안정적인 게임 제공  

## 📎 추가 정보  
- 엔드포인트: `GET /games/{gameId}`  
- 응답 예시: SceneType에 맞는 DTO를 리턴


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 게임 세션 완료(DONE) 결과에 보상 정보가 추가되었습니다. 획득한 아이템 이름 목록과 힘/민첩/지능/행운/생명/골드 보상을 확인할 수 있습니다. 보상 정보는 진행 현황, 배경, 장소 등과 함께 표시되어 완료 요약이 더욱 명확해졌습니다.
- Refactor
  - 예외 처리 정책을 정비하여 특정 오류 상황의 응답 일관성을 개선했습니다.
- Style
  - 일부 코드의 공백/정렬 등 스타일을 정리하여 가독성을 개선했습니다. 동작에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->