### PR TITLE
Feature/155 get pia items

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/UserController.java
+++ b/src/main/java/com/scriptopia/demo/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.scriptopia.demo.controller;
 
+import com.scriptopia.demo.dto.users.PiaItemDTO;
 import com.scriptopia.demo.dto.users.UserAssetsResponse;
 import com.scriptopia.demo.dto.users.UserSettingsDTO;
 import com.scriptopia.demo.service.UserService;
@@ -10,12 +11,25 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/users/me")
 @RequiredArgsConstructor
 public class UserController {
 
     private final UserService userService;
+
+
+    @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
+    @GetMapping("/items/pia")
+    public ResponseEntity<List<PiaItemDTO>> getPiaItems(
+            Authentication authentication
+    ) {
+        String userId = authentication.getName();
+        List<PiaItemDTO> response = userService.getPiaItems(userId);
+        return ResponseEntity.ok(response);
+    }
 
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/settings")
@@ -47,5 +61,7 @@ public class UserController {
         UserAssetsResponse response = userService.getUserAssets(userId);
         return ResponseEntity.ok(response);
     }
+
+
 
 }

--- a/src/main/java/com/scriptopia/demo/dto/users/PiaItemDTO.java
+++ b/src/main/java/com/scriptopia/demo/dto/users/PiaItemDTO.java
@@ -1,0 +1,15 @@
+package com.scriptopia.demo.dto.users;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class PiaItemDTO {
+    private String name;
+    private Long quantity;
+}

--- a/src/main/java/com/scriptopia/demo/repository/UserPiaItemRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/UserPiaItemRepository.java
@@ -5,8 +5,11 @@ import com.scriptopia.demo.domain.User;
 import com.scriptopia.demo.domain.UserPiaItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserPiaItemRepository extends JpaRepository<UserPiaItem, Long> {
     Optional<UserPiaItem> findByUserAndPiaItem(User user, PiaItem piaItem);
+
+    List<UserPiaItem> findByUserId(Long UserId);
 }

--- a/src/main/java/com/scriptopia/demo/service/UserService.java
+++ b/src/main/java/com/scriptopia/demo/service/UserService.java
@@ -1,11 +1,14 @@
 package com.scriptopia.demo.service;
 
 import com.scriptopia.demo.domain.User;
+import com.scriptopia.demo.domain.UserPiaItem;
 import com.scriptopia.demo.domain.UserSetting;
+import com.scriptopia.demo.dto.users.PiaItemDTO;
 import com.scriptopia.demo.dto.users.UserAssetsResponse;
 import com.scriptopia.demo.dto.users.UserSettingsDTO;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
+import com.scriptopia.demo.repository.UserPiaItemRepository;
 import com.scriptopia.demo.repository.UserRepository;
 import com.scriptopia.demo.repository.UserSettingRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +26,7 @@ public class UserService {
 
     private final UserSettingRepository userSettingRepository;
     private final UserRepository userRepository;
+    private final UserPiaItemRepository userPiaItemRepository;
 
     @Transactional
     public UserSettingsDTO getUserSettings(String userId){
@@ -57,7 +63,6 @@ public class UserService {
 
     @Transactional
     public UserAssetsResponse getUserAssets(String userId){
-
         User user = userRepository.findById(Long.valueOf(userId)).orElseThrow(
                 () -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND)
         );
@@ -66,6 +71,24 @@ public class UserService {
                 .pia(user.getPia())
                 .build();
 
+    }
+
+    @Transactional
+    public List<PiaItemDTO>  getPiaItems(String userId){
+        User user = userRepository.findById(Long.valueOf(userId)).orElseThrow(
+                () -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND)
+        );
+        List<PiaItemDTO> piaItems = new ArrayList<>();
+        for (UserPiaItem userPiaItem : userPiaItemRepository.findByUserId(Long.valueOf(userId))) {
+            piaItems.add(
+                    PiaItemDTO.builder()
+                            .name(userPiaItem.getPiaItem().getName())
+                            .quantity(userPiaItem.getQuantity())
+                            .build()
+            );
+        }
+
+        return piaItems;
     }
 
 


### PR DESCRIPTION
## 🚀 관련 이슈

Close #155

## 📑 PR 설명
사용자 피아 아이템 조회 API 구현

## ✏️ 작업 내용
사용자 피아 아이템 조회 API 구현
## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 빌드 통과 확인
- [x] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그인한 사용자가 자신의 PIA 아이템 목록을 조회할 수 있는 새 엔드포인트가 추가되었습니다.
  - 응답에는 각 아이템의 이름과 수량이 포함되어, 마이페이지/인벤토리 화면에서 바로 표시할 수 있습니다.
  - 권한이 있는 사용자만 접근 가능하며, 표준 200 응답으로 안정적으로 데이터를 제공합니다.
  - 모바일/웹 클라이언트에서 쉽게 소비 가능한 단순 리스트 형태로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->