### PR TITLE
[Feature] 공유된 게임 무한스크롤

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -2,6 +2,7 @@ package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.domain.SharedGame;
 import com.scriptopia.demo.domain.SharedGameFavorite;
+import com.scriptopia.demo.domain.SharedGameSort;
 import com.scriptopia.demo.dto.TagDef.TagDefCreateRequest;
 import com.scriptopia.demo.dto.TagDef.TagDefDeleteRequest;
 import com.scriptopia.demo.dto.sharedgame.CursorPage;
@@ -43,12 +44,13 @@ public class SharedGameController {
      */
     @GetMapping
     public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
-                                                                                     @RequestParam(required = false) Long lastId,
+                                                                                     @RequestParam(required = false) UUID lastUUID,
                                                                                      @RequestParam(defaultValue = "20") int size,
                                                                                      @RequestParam(required = false) List<Long> tagIds,
-                                                                                     @RequestParam(required = false) String query) {
+                                                                                     @RequestParam(required = false) String query,
+                                                                                     @RequestParam(defaultValue = "LATEST")SharedGameSort sort) {
         Long viewerId = (authentication == null) ? null : Long.valueOf(authentication.getName());
-        return sharedGameService.getPublicSharedGames(viewerId, lastId, size, tagIds, query);
+        return sharedGameService.getPublicSharedGames(viewerId, lastUUID, size, tagIds, query, sort);
     }
 
     /*

--- a/src/main/java/com/scriptopia/demo/controller/UserController.java
+++ b/src/main/java/com/scriptopia/demo/controller/UserController.java
@@ -69,7 +69,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/my-page/history")
+    @GetMapping("/games/histories")
     public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) UUID lastId,
                                                                 @RequestParam(defaultValue = "10") int size,
                                                                 Authentication authentication) {

--- a/src/main/java/com/scriptopia/demo/domain/SharedGame.java
+++ b/src/main/java/com/scriptopia/demo/domain/SharedGame.java
@@ -26,8 +26,6 @@ public class SharedGame {
     private UUID uuid;
 
     private String thumbnailUrl;
-    private Long recommend = 0L;
-    private Long totalPlayed = 0L;
 
     @Column(columnDefinition = "TEXT")
     private String title;

--- a/src/main/java/com/scriptopia/demo/domain/SharedGameSort.java
+++ b/src/main/java/com/scriptopia/demo/domain/SharedGameSort.java
@@ -1,0 +1,7 @@
+package com.scriptopia.demo.domain;
+
+public enum SharedGameSort {
+    LATEST,
+    POPULAR,
+    TOP_SCORE
+}

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/CursorPage.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/CursorPage.java
@@ -1,5 +1,6 @@
 package com.scriptopia.demo.dto.sharedgame;
 
 import java.util.List;
+import java.util.UUID;
 
-public record CursorPage<T>(List<T> items, Long nextCursor, boolean hasNext) {}
+public record CursorPage<T>(List<T> items, UUID nextCursor, boolean hasNext) {}

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
@@ -4,10 +4,11 @@ import lombok.Data;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @Data
 public class PublicSharedGameResponse {
-    private Long sharedGameId;
+    private UUID sharedGameId;
     private String thumbnailUrl;
     private boolean isLiked;
     private Long likeCount;

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,43 +20,92 @@ public interface SharedGameRepository extends JpaRepository<SharedGame, Long> {
     @Query("select sg from SharedGame sg where sg.uuid = :uuid")
     Optional<SharedGame> findByUuid(@Param("uuid") UUID uuid);
 
-    // 기본(전체)
-    @Query("""
-        select g from SharedGame g
-        where (:lastId is null or g.id < :lastId)
-        order by g.id desc
-    """)
-    Page<SharedGame> pageAll(@Param("lastId") Long lastId, Pageable pageable);
+    @Query("select g.sharedAt from SharedGame g where g.id = :id")
+    LocalDateTime findSharedAtById(@Param("id") Long id);
 
-    // 🔎 검색 전용 (태그 무시)
+    // 최신순
     @Query("""
-        select g from SharedGame g
-        where (:lastId is null or g.id < :lastId)
-          and (
-            lower(g.title) like lower(concat('%', :q, '%'))
-            or lower(g.worldView) like lower(concat('%', :q, '%'))
-            or lower(g.backgroundStory) like lower(concat('%', :q, '%'))
-          )
-        order by g.id desc
+    select g
+    from SharedGame g
+    where (:tagEmpty = true
+           or exists (select 1 from GameTag gt where gt.sharedGame = g and gt.tagDef.id in :tagIds))
+      and (:qBlank = true
+           or lower(coalesce(g.title,''))           like :qLike
+           or lower(coalesce(g.worldView,''))       like :qLike
+           or lower(coalesce(g.backgroundStory,'')) like :qLike)
+      and (
+           :useCursor = false
+           or g.sharedAt < :lastKey
+           or (g.sharedAt = :lastKey and g.id < :lastId)
+      )
+    order by g.sharedAt desc, g.id desc
     """)
-    Page<SharedGame> pageSearchOnly(@Param("lastId") Long lastId,
-                                    @Param("q") String q,
-                                    Pageable pageable);
+    List<SharedGame> sliceLatest(
+            @Param("tagIds") List<Long> tagIds, @Param("tagEmpty") boolean tagEmpty,
+            @Param("qLike") String qLike, @Param("qBlank") boolean qBlank,
+            @Param("useCursor") boolean useCursor,
+            @Param("lastKey") LocalDateTime lastKey, @Param("lastId") Long lastId,
+            Pageable pageable
+    );
 
-
-    // 🏷 태그 ALL 전용 (검색 없음)
     @Query("""
-        select g from SharedGame g
-        join GameTag gt on gt.sharedGame = g
-        join TagDef td on td = gt.tagDef
-        where (:lastId is null or g.id < :lastId)
-          and td.id in :tagIds
-        group by g.id
-        having count(distinct td.id) = :tagCount
-        order by g.id desc
+    select g
+    from SharedGame g
+    where (:tagEmpty = true
+           or exists (select 1 from GameTag gt where gt.sharedGame = g and gt.tagDef.id in :tagIds))
+      and (:qBlank = true
+           or lower(coalesce(g.title,'')) like :qLike
+           or lower(coalesce(g.worldView,'')) like :qLike
+           or lower(coalesce(g.backgroundStory,'')) like :qLike)
+      and (
+           :useCursor = false
+           or (
+               (select count(s.id) from SharedGameScore s where s.sharedGame = g) < :lastKey
+               or (
+                   (select count(s2.id) from SharedGameScore s2 where s2.sharedGame = g) = :lastKey
+                   and g.id < :lastId
+               )
+           )
+      )
+    order by (select count(s3.id) from SharedGameScore s3 where s3.sharedGame = g) desc,
+             g.id desc
     """)
-    Page<SharedGame> pageByAllTagsOnly(@Param("lastId") Long lastId,
-                                       @Param("tagIds") List<Long> tagIds,
-                                       @Param("tagCount") long tagCount,
-                                       Pageable pageable);
+    List<SharedGame> slicePopular(
+            @Param("tagIds") List<Long> tagIds, @Param("tagEmpty") boolean tagEmpty,
+            @Param("qLike") String qLike, @Param("qBlank") boolean qBlank,
+            @Param("useCursor") boolean useCursor,
+            @Param("lastKey") Long lastKey, @Param("lastId") Long lastId,
+            Pageable pageable
+    );
+
+    @Query("""
+    select g
+    from SharedGame g
+    where (:tagEmpty = true
+           or exists (select 1 from GameTag gt where gt.sharedGame = g and gt.tagDef.id in :tagIds))
+      and (:qBlank = true
+           or lower(coalesce(g.title,'')) like :qLike
+           or lower(coalesce(g.worldView,'')) like :qLike
+           or lower(coalesce(g.backgroundStory,'')) like :qLike)
+      and (
+           :useCursor = false
+           or (
+               (select coalesce(max(s.score),0) from SharedGameScore s where s.sharedGame = g) < :lastKey
+               or (
+                   (select coalesce(max(s2.score),0) from SharedGameScore s2 where s2.sharedGame = g) = :lastKey
+                   and g.id < :lastId
+               )
+           )
+      )
+    order by (select coalesce(max(s3.score),0) from SharedGameScore s3 where s3.sharedGame = g) desc,
+             g.id desc
+    """)
+    List<SharedGame> sliceTopScore(
+            @Param("tagIds") List<Long> tagIds, @Param("tagEmpty") boolean tagEmpty,
+            @Param("qLike") String qLike, @Param("qBlank") boolean qBlank,
+            @Param("useCursor") boolean useCursor,
+            @Param("lastKey") Long lastKey, @Param("lastId") Long lastId,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
@@ -2,6 +2,7 @@ package com.scriptopia.demo.repository;
 
 import com.scriptopia.demo.domain.SharedGame;
 import com.scriptopia.demo.domain.SharedGameScore;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,8 +12,8 @@ public interface SharedGameScoreRepository extends JpaRepository<SharedGameScore
     @Query("Select count(s) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
     long countBySharedGameId(Long sharedGameId);
 
-    @Query("select max(s.score) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
-    Long maxScoreBySharedGameId(Long sharedGameId);
+    @Query("select coalesce(max(s.score), 0) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
+    Long maxScoreBySharedGameId(@Param("sharedGameId") Long sharedGameId);
 
     List<SharedGameScore> findAllBySharedGameIdOrderByScoreDescCreatedAtDesc(Long sharedGameId);
 }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -8,10 +8,12 @@ import com.scriptopia.demo.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -105,7 +107,7 @@ public class SharedGameService {
         dto.setSharedGameUUID(game.getUuid());
         dto.setNickname(game.getUser().getNickname());
         dto.setThumbnailUrl(game.getThumbnailUrl());
-        dto.setTotalPlayed(game.getTotalPlayed());
+        dto.setTotalPlayed(sharedGameScoreRepository.countBySharedGameId(game.getId()));
         dto.setTitle(game.getTitle());
         dto.setWorldView(game.getWorldView());
         dto.setBackgroundStory(game.getBackgroundStory());
@@ -144,47 +146,97 @@ public class SharedGameService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Long userId, Long lastId, int size,
-                                                                                     List<Long> tagIds, String q) {
+    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Long userId,
+                                                                               UUID lastUuid,
+                                                                               int size,
+                                                                               List<Long> tagIds,
+                                                                               String q,
+                                                                               SharedGameSort sort) {
+        String raw = (q == null) ? "" : q;
+        String trimmed = raw.strip();
+        boolean qBlank = trimmed.isEmpty();
+        String qLike = "%" + trimmed.toLowerCase() + "%";
 
-        PageRequest pr = PageRequest.of(0, size);
-        Page<SharedGame> page;
+        // 2) 태그/커서/정렬 전처리
+        boolean tagEmpty = (tagIds == null || tagIds.isEmpty());
+        SharedGameSort effectiveSort = qBlank ? sort : SharedGameSort.LATEST;
 
-        boolean hasQ = q != null && q.isBlank();
-        boolean hasTags = tagIds != null && !tagIds.isEmpty();
+        boolean useCursor = (lastUuid != null);
+        Long lastId = null;
+        LocalDateTime lastSharedAt = null;
+        Long lastPlayCount = null;
+        Long lastTopScore = null;
 
-        if(hasQ) {
-            page = sharedGameRepository.pageSearchOnly(lastId, q.trim(), pr);
+        if (useCursor) {
+            SharedGame pivot = sharedGameRepository.findByUuid(lastUuid)
+                    .orElseThrow(() -> new CustomException(ErrorCode.E_404_PAGE_NOT_FOUND));
+            lastId = pivot.getId();
+
+            switch (effectiveSort) {
+                case LATEST -> lastSharedAt = pivot.getSharedAt();
+                case POPULAR -> lastPlayCount = sharedGameScoreRepository.countBySharedGameId(lastId);
+                case TOP_SCORE -> {
+                    Long max = sharedGameScoreRepository.maxScoreBySharedGameId(lastId);
+                    lastTopScore = (max == null) ? 0L : max;
+                }
+            }
         }
-        else if(hasTags) {
-            page = sharedGameRepository.pageByAllTagsOnly(lastId, tagIds, tagIds.size(), pr);
-        }
-        else {
-            page = sharedGameRepository.pageAll(lastId, pr);
-        }
 
-        var items = page.getContent().stream().map(g -> {
-            var dto = new PublicSharedGameResponse();
-            dto.setSharedGameId(g.getId());
+        // 3) 페이지 사이즈/페이징
+        Pageable pageable = PageRequest.of(0, Math.max(1, size));
+
+        // 4) 정렬 스위치별 슬라이스 조회 (qLike/qBlank 사용)
+        List<SharedGame> rows = switch (effectiveSort) {
+            case LATEST -> sharedGameRepository.sliceLatest(
+                    tagEmpty ? List.of(-1L) : tagIds, tagEmpty,
+                    qLike, qBlank,
+                    useCursor, lastSharedAt, lastId,
+                    pageable
+            );
+            case POPULAR -> sharedGameRepository.slicePopular(
+                    tagEmpty ? List.of(-1L) : tagIds, tagEmpty,
+                    qLike, qBlank,
+                    useCursor, lastPlayCount, lastId,
+                    pageable
+            );
+            case TOP_SCORE -> sharedGameRepository.sliceTopScore(
+                    tagEmpty ? List.of(-1L) : tagIds, tagEmpty,
+                    qLike, qBlank,
+                    useCursor, lastTopScore, lastId,
+                    pageable
+            );
+        };
+
+        // 5) DTO 매핑 (집계 일원화)
+        List<PublicSharedGameResponse> items = rows.stream().map(g -> {
+            PublicSharedGameResponse dto = new PublicSharedGameResponse();
+            dto.setSharedGameId(g.getUuid());
             dto.setThumbnailUrl(g.getThumbnailUrl());
             dto.setTitle(g.getTitle());
-            dto.setTopScore(sharedGameScoreRepository.maxScoreBySharedGameId(g.getId()));
             dto.setSharedAt(g.getSharedAt());
 
+            // 집계
             dto.setTotalPlayCount(sharedGameScoreRepository.countBySharedGameId(g.getId()));
             dto.setLikeCount(sharedGameFavoriteRepository.countBySharedGameId(g.getId()));
 
-            if(userId != null) {
-                dto.setLiked(sharedGameFavoriteRepository.existsByUserIdAndSharedGameId(userId, g.getId()));
+            Long topScore = sharedGameScoreRepository.maxScoreBySharedGameId(g.getId());
+            dto.setTopScore(topScore == null ? 0L : topScore);
+
+            // 좋아요 여부
+            if (userId != null) {
+                boolean liked = sharedGameFavoriteRepository.existsByUserIdAndSharedGameId(userId, g.getId());
+                dto.setLiked(liked);
             }
 
-            List<TagDto> tags = gameTagRepository.findTagDtosBySharedGameId(g.getId());
-            dto.setTags(tags);
-
+            // 태그
+            dto.setTags(gameTagRepository.findTagDtosBySharedGameId(g.getId()));
             return dto;
         }).toList();
 
-        Long nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getSharedGameId();
-        return ResponseEntity.ok(new CursorPage<>(items, nextCursor, page.hasNext()));
+        // 6) 커서/hasNext
+        UUID nextCursor = items.isEmpty() ? null : items.get(items.size() - 1).getSharedGameId();
+        boolean hasNext = rows.size() == Math.max(1, size);
+
+        return ResponseEntity.ok(new CursorPage<>(items, nextCursor, hasNext));
     }
 }


### PR DESCRIPTION
## 🚀 관련 이슈

Close #173 

## 📑 PR 설명
공유된 게임 무한스크롤 구현

## ✏️ 작업 내용
공유된 게임 무한스크롤 구현

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 공개 공유 게임 목록에 정렬 옵션 추가(LATEST 기본, POPULAR, TOP_SCORE)와 UUID 기반 커서 페이지네이션 도입. 태그/검색 필터 동작 개선.
  - 응답 데이터에 최고 점수, 총 플레이 수, 좋아요 수, 좋아요 여부가 일관되게 제공됩니다.
- Breaking Changes
  - 목록 API의 식별자/커서가 Long에서 UUID로 변경(sharedGameId, nextCursor).
  - 내 히스토리 조회 경로가 /my-page/history → /games/histories 로 변경.
- Bug Fixes
  - 최고 점수가 없는 경우 0으로 표시되어 빈 값(null) 노출을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->