### PR TITLE
Feature/choice shop create 180

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -139,6 +139,19 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
+    @DeleteMapping("/sellItem/{gameId}/{itemId}")
+    public ResponseEntity<GameSessionMongo> sellItem(
+            @PathVariable("gameId") String gameId,
+            @PathVariable("itemId") String itemId,
+            Authentication authentication) throws JsonProcessingException {
+
+        Long userId = Long.valueOf(authentication.getName());
+
+        GameSessionMongo response = gameSessionService.gameSellItem(userId, itemId);
+
+        return ResponseEntity.ok(response);
+    }
 
     /*
      * 게임 -> 기존 게임 조회

--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -125,6 +125,20 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
+    @DeleteMapping("/buyItem/{gameId}/{itemId}")
+    public ResponseEntity<GameSessionMongo> buyItem(
+            @PathVariable("gameId") String gameId,
+            @PathVariable("itemId") String itemId,
+            Authentication authentication) throws JsonProcessingException {
+
+        Long userId = Long.valueOf(authentication.getName());
+
+        GameSessionMongo response = gameSessionService.gameBuyItem(userId, itemId);
+
+        return ResponseEntity.ok(response);
+    }
+
 
     /*
      * 게임 -> 기존 게임 조회

--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -126,7 +126,7 @@ public class GameSessionController {
     }
 
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
-    @DeleteMapping("/buyItem/{gameId}/{itemId}")
+    @PostMapping("/{gameId}/items/purchase/{itemId}")
     public ResponseEntity<GameSessionMongo> buyItem(
             @PathVariable("gameId") String gameId,
             @PathVariable("itemId") String itemId,
@@ -140,7 +140,7 @@ public class GameSessionController {
     }
 
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
-    @DeleteMapping("/sellItem/{gameId}/{itemId}")
+    @PostMapping("/{gameId}/items/sell/{itemId}")
     public ResponseEntity<GameSessionMongo> sellItem(
             @PathVariable("gameId") String gameId,
             @PathVariable("itemId") String itemId,

--- a/src/main/java/com/scriptopia/demo/domain/ChoiceResultType.java
+++ b/src/main/java/com/scriptopia/demo/domain/ChoiceResultType.java
@@ -7,10 +7,10 @@ import java.security.SecureRandom;
 
 @Getter
 public enum ChoiceResultType {
-    BATTLE(20),
-    CHOICE(40),
-    DONE(45),
-    SHOP(5);
+    BATTLE(2),       // 20, 40, 45, 5
+    CHOICE(3),
+    DONE(5),
+    SHOP(90);
 
     private final int nextEventType;
 

--- a/src/main/java/com/scriptopia/demo/domain/mongo/ShopInfoMongo.java
+++ b/src/main/java/com/scriptopia/demo/domain/mongo/ShopInfoMongo.java
@@ -9,5 +9,5 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ShopInfoMongo {
-    private List<Long> itemDefId;
+    private List<String> itemDefId;
 }

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopResponse.java
@@ -1,4 +1,31 @@
 package com.scriptopia.demo.dto.gamesession.ingame;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class InGameShopResponse {
+    private String sceneType;
+    private LocalDateTime startedAt;
+    private LocalDateTime updatedAt;
+    private String background;
+    private String location;
+    private int progress;
+    private int stageSize;
+
+    private InGamePlayerResponse playerInfo; // 외부
+    private InGameNpcResponse npcInfo; // 외부
+    private List<InGameInventoryResponse> inventory; // 외부
+
+    private List<InGameShopTable> shopTable; // 외부
+
+
 }

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopTable.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopTable.java
@@ -1,0 +1,4 @@
+package com.scriptopia.demo.dto.gamesession.ingame;
+
+public class InGameShopTable {
+}

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopTable.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopTable.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class InGameShopTable {
 
     // 아이템 정의 정보
+    private String shopItemId;
     private String name;
     private String description;
     private String itemPicSrc;

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopTable.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/ingame/InGameShopTable.java
@@ -1,4 +1,41 @@
 package com.scriptopia.demo.dto.gamesession.ingame;
 
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class InGameShopTable {
+
+    // 아이템 정의 정보
+    private String name;
+    private String description;
+    private String itemPicSrc;
+    private String category;
+    private int baseStat;
+    private List<ItemEffect> itemEffects;
+    private int strength;
+    private int agility;
+    private int intelligence;
+    private int luck;
+    private String mainStat;
+    private String grade;
+    private int price;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ItemEffect {
+        private String itemEffectName;
+        private String itemEffectDescription;
+        private String grade;
+    }
 }

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -84,6 +84,7 @@ public enum ErrorCode {
     E_409_REFRESH_REUSE_DETECTED("E409003", "리프레시 토큰 재사용이 감지되었습니다.", HttpStatus.CONFLICT),
     E_409_PASSWORD_SAME_AS_OLD("E409004","기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.",HttpStatus.CONFLICT),
     E_409_ALREADY_CONFIRMED("E409005","이미 정산이 완료된 항목입니다.", HttpStatus.CONFLICT),
+    E_409_NOT_ENOUGH_MONEY("E4090056", "보유 금액이 부족합니다.", HttpStatus.CONFLICT),
 
 
     //412 Precondition Failed

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -86,6 +86,8 @@ public enum ErrorCode {
     E_409_ALREADY_CONFIRMED("E409005","이미 정산이 완료된 항목입니다.", HttpStatus.CONFLICT),
     E_409_NOT_ENOUGH_MONEY("E409006", "보유 금액이 부족합니다.", HttpStatus.CONFLICT),
     E_409_NOT_THIS_SCENE("E409007", "적합하지 않은 곳입니다.", HttpStatus.CONFLICT),
+    E_409_DONT_SELL_EQUIPPED_ITEM("E409008", "착용중인 아이템은 팔 수 없습니다.", HttpStatus.CONFLICT),
+    E_404_ITEM_NOT_IN_SHOP("E409009", "아이템이 이미 팔렸습니다.", HttpStatus.CONFLICT),
 
 
     //412 Precondition Failed

--- a/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
+++ b/src/main/java/com/scriptopia/demo/exception/ErrorCode.java
@@ -84,7 +84,8 @@ public enum ErrorCode {
     E_409_REFRESH_REUSE_DETECTED("E409003", "리프레시 토큰 재사용이 감지되었습니다.", HttpStatus.CONFLICT),
     E_409_PASSWORD_SAME_AS_OLD("E409004","기존 비밀번호와 동일한 비밀번호는 사용할 수 없습니다.",HttpStatus.CONFLICT),
     E_409_ALREADY_CONFIRMED("E409005","이미 정산이 완료된 항목입니다.", HttpStatus.CONFLICT),
-    E_409_NOT_ENOUGH_MONEY("E4090056", "보유 금액이 부족합니다.", HttpStatus.CONFLICT),
+    E_409_NOT_ENOUGH_MONEY("E409006", "보유 금액이 부족합니다.", HttpStatus.CONFLICT),
+    E_409_NOT_THIS_SCENE("E409007", "적합하지 않은 곳입니다.", HttpStatus.CONFLICT),
 
 
     //412 Precondition Failed

--- a/src/main/java/com/scriptopia/demo/mapper/InGameMapper.java
+++ b/src/main/java/com/scriptopia/demo/mapper/InGameMapper.java
@@ -112,6 +112,7 @@ public class InGameMapper {
                     return InGameShopTable.builder()
 
                             // 아이템 정의 정보
+                            .shopItemId(itemDef.getId())
                             .name(itemDef.getName())
                             .description(itemDef.getDescription())
                             .itemPicSrc(itemDef.getItemPicSrc())

--- a/src/main/java/com/scriptopia/demo/mapper/InGameMapper.java
+++ b/src/main/java/com/scriptopia/demo/mapper/InGameMapper.java
@@ -2,10 +2,7 @@ package com.scriptopia.demo.mapper;
 
 
 import com.scriptopia.demo.domain.mongo.*;
-import com.scriptopia.demo.dto.gamesession.ingame.InGameChoiceResponse;
-import com.scriptopia.demo.dto.gamesession.ingame.InGameInventoryResponse;
-import com.scriptopia.demo.dto.gamesession.ingame.InGameNpcResponse;
-import com.scriptopia.demo.dto.gamesession.ingame.InGamePlayerResponse;
+import com.scriptopia.demo.dto.gamesession.ingame.*;
 import com.scriptopia.demo.exception.CustomException;
 import com.scriptopia.demo.exception.ErrorCode;
 import com.scriptopia.demo.repository.mongo.ItemDefMongoRepository;
@@ -106,6 +103,37 @@ public class InGameMapper {
                 .toList();
     }
 
+    public List<InGameShopTable> mapShopTable(List<String> createShopItems) {
+        return createShopItems.stream()
+                .map(shopItem -> {
+                    ItemDefMongo itemDef = itemDefMongoRepository.findById(shopItem)
+                            .orElseThrow(() -> new CustomException(ErrorCode.E_404_ITEM_NOT_FOUND));
 
+                    return InGameShopTable.builder()
+
+                            // 아이템 정의 정보
+                            .name(itemDef.getName())
+                            .description(itemDef.getDescription())
+                            .itemPicSrc(itemDef.getItemPicSrc())
+                            .category(itemDef.getCategory().name())
+                            .baseStat(itemDef.getBaseStat())
+                            .itemEffects(itemDef.getItemEffect().stream()
+                                    .map(e -> InGameShopTable.ItemEffect.builder()
+                                            .itemEffectName(e.getItemEffectName())
+                                            .itemEffectDescription(e.getItemEffectDescription())
+                                            .grade(e.getEffectProbability().name())
+                                            .build())
+                                    .toList())
+                            .strength(itemDef.getStrength())
+                            .agility(itemDef.getAgility())
+                            .intelligence(itemDef.getIntelligence())
+                            .luck(itemDef.getLuck())
+                            .mainStat(itemDef.getMainStat().name())
+                            .grade(itemDef.getGrade().name())
+                            .price(itemDef.getPrice().intValue())
+                            .build();
+                })
+                .toList();
+    }
 
 }

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -969,6 +969,10 @@ public class GameSessionService {
         GameSessionMongo gameSessionMongo = gameSessionMongoRepository.findById(gameSession.getMongoId())
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND));
 
+        if (gameSessionMongo.getSceneType() != SceneType.SHOP) {
+            throw new CustomException(ErrorCode.E_409_NOT_THIS_SCENE);
+        }
+
         PlayerInfoMongo playerInfo = gameSessionMongo.getPlayerInfo();
         List<InventoryMongo> inventory = gameSessionMongo.getInventory();
         ShopInfoMongo shopInfoMongo = gameSessionMongo.getShopInfo();

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -3,6 +3,7 @@ package com.scriptopia.demo.service;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameBattleResponse;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameChoiceResponse;
 import com.scriptopia.demo.dto.gamesession.ingame.InGameDoneResponse;
+import com.scriptopia.demo.dto.gamesession.ingame.InGameShopResponse;
 import com.scriptopia.demo.dto.items.ItemDefRequest;
 import com.scriptopia.demo.dto.items.ItemFastApiResponse;
 import com.scriptopia.demo.mapper.InGameMapper;
@@ -339,6 +340,20 @@ public class GameSessionService {
 
         } else if (currentSceneType == SceneType.SHOP) {
 
+            return InGameShopResponse.builder()
+                    .sceneType("SHOP")
+                    .startedAt(gameSessionMongo.getStartedAt())
+                    .updatedAt(LocalDateTime.now())
+                    .background(gameSessionMongo.getBackground())
+                    .location(gameSessionMongo.getLocation())
+                    .stageSize(gameSessionMongo.getStage() != null ? gameSessionMongo.getStage().size() : 0)
+                    .playerInfo(inGameMapper.mapPlayer(gameSessionMongo.getPlayerInfo()))
+                    .npcInfo(inGameMapper.mapNpc(gameSessionMongo.getNpcInfo()))
+                    .inventory(inGameMapper.mapInventory(gameSessionMongo.getInventory()))
+                    .shopTable(inGameMapper.mapShopTable(gameSessionMongo.getShopInfo().getItemDefId()))
+                    .build();
+
+
         } else if (currentSceneType == SceneType.BATTLE) {
             BattleInfoMongo battleInfo = gameSessionMongo.getBattleInfo();
 
@@ -406,6 +421,9 @@ public class GameSessionService {
                 gameToDone(userId);
             }
             case SceneType.DONE -> {
+                gameToChoice(userId);
+            }
+            case SceneType.SHOP -> {
                 gameToChoice(userId);
             }
             default -> throw new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND);
@@ -807,7 +825,7 @@ public class GameSessionService {
         ChoiceResultType nextScene = choiceMongo.getResultType();
         boolean isPass = GameBalanceUtil.isPass(probability);
 
-        RewardInfoMongo rewardInfo;
+        RewardInfoMongo rewardInfo = null;
 
         switch (nextScene) {
             case CHOICE -> {
@@ -826,6 +844,33 @@ public class GameSessionService {
 
                 gameSessionMongo = gameSessionMongoRepository.findById(gameId).get();
                 rewardInfo = handleReward(gameSessionMongo, rewardType, isPass);
+            }
+            case SHOP -> {
+                gameSessionMongo = gameSessionMongoRepository.findById(gameId).get();
+                List<String> createdItems = gameSessionMongo.getCreatedItems();
+                List<String> createShopItems = new ArrayList<>();
+
+                ItemDefRequest itemDefRequest = ItemDefRequest.builder()
+                        .worldView(gameSessionMongo.getHistoryInfo().getWorldView())
+                        .location(gameSessionMongo.getLocation())
+                        .playerTrait(null)
+                        .previousStory(gameSessionMongo.getBackground())
+                        .build();
+
+                for (int i=0; i<3; i+=1){
+                    String itemMongoId = itemService.createItemInGame(itemDefRequest);
+                    createdItems.add(itemMongoId);
+                    createShopItems.add(itemMongoId);
+                }
+
+                ShopInfoMongo shopInfoMongo = ShopInfoMongo.builder()
+                        .itemDefId(createShopItems)
+                        .build();
+
+                gameSessionMongo.setCreatedItems(createdItems);
+                gameSessionMongo.setShopInfo(shopInfoMongo);
+                gameSessionMongo.setSceneType(SceneType.SHOP);
+
             }
             default -> throw new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND);
         }

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -961,6 +961,49 @@ public class GameSessionService {
     }
 
 
+    @Transactional
+    public GameSessionMongo gameBuyItem(Long userId, String itemId) {
+        GameSession gameSession = gameSessionRepository.findByMongoId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND));
+
+        GameSessionMongo gameSessionMongo = gameSessionMongoRepository.findById(gameSession.getMongoId())
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND));
+
+        PlayerInfoMongo playerInfo = gameSessionMongo.getPlayerInfo();
+        List<InventoryMongo> inventory = gameSessionMongo.getInventory();
+        ShopInfoMongo shopInfoMongo = gameSessionMongo.getShopInfo();
+        List<String> shopItems = shopInfoMongo.getItemDefId();
+
+        long playerGold = playerInfo.getGold();
+
+
+        ItemDefMongo targetDef = itemDefMongoRepository.findById(itemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_ITEM_NOT_FOUND));
+
+        long shopItemGold = targetDef.getPrice();
+
+        if(playerGold < shopItemGold){
+            throw new CustomException(ErrorCode.E_409_NOT_ENOUGH_MONEY);
+        }
+
+
+        InventoryMongo buyItem = InventoryMongo.builder()
+                .itemDefId(itemId)
+                .acquiredAt(LocalDateTime.now())
+                .equipped(false)
+                .source("item shop")
+                .build();
+
+        inventory.add(buyItem);
+        shopItems.remove(itemId);
+        shopInfoMongo.setItemDefId(shopItems);
+
+        gameSessionMongo.setInventory(inventory);
+        gameSessionMongo.setShopInfo(shopInfoMongo);
+
+        return gameSessionMongoRepository.save(gameSessionMongo);
+    }
+
 
     private void addStats(PlayerInfoMongo player, ItemDefMongo item) {
         player.setStrength(player.getStrength() + safeStat(item.getStrength()));

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -980,6 +980,9 @@ public class GameSessionService {
 
         long playerGold = playerInfo.getGold();
 
+        if (!shopItems.contains(itemId)) {
+            throw new CustomException(ErrorCode.E_404_ITEM_NOT_IN_SHOP);
+        }
 
         ItemDefMongo targetDef = itemDefMongoRepository.findById(itemId)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_ITEM_NOT_FOUND));
@@ -990,6 +993,12 @@ public class GameSessionService {
             throw new CustomException(ErrorCode.E_409_NOT_ENOUGH_MONEY);
         }
 
+        playerGold = playerGold - shopItemGold;
+        playerInfo.setGold(playerGold);
+
+
+        shopItems.remove(itemId);
+        shopInfoMongo.setItemDefId(shopItems);
 
         InventoryMongo buyItem = InventoryMongo.builder()
                 .itemDefId(itemId)
@@ -999,11 +1008,50 @@ public class GameSessionService {
                 .build();
 
         inventory.add(buyItem);
-        shopItems.remove(itemId);
-        shopInfoMongo.setItemDefId(shopItems);
+
 
         gameSessionMongo.setInventory(inventory);
         gameSessionMongo.setShopInfo(shopInfoMongo);
+        gameSessionMongo.setPlayerInfo(playerInfo);
+
+        return gameSessionMongoRepository.save(gameSessionMongo);
+    }
+
+    @Transactional
+    public GameSessionMongo gameSellItem(Long userId, String itemId) {
+        GameSession gameSession = gameSessionRepository.findByMongoId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND));
+
+        GameSessionMongo gameSessionMongo = gameSessionMongoRepository.findById(gameSession.getMongoId())
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_GAME_SESSION_NOT_FOUND));
+
+        if (gameSessionMongo.getSceneType() != SceneType.SHOP) {
+            throw new CustomException(ErrorCode.E_409_NOT_THIS_SCENE);
+        }
+
+        PlayerInfoMongo playerInfo = gameSessionMongo.getPlayerInfo();
+        List<InventoryMongo> inventory = gameSessionMongo.getInventory();
+        long playerGold = playerInfo.getGold();
+
+        InventoryMongo targetInventory = inventory.stream()
+                .filter(inv -> inv.getItemDefId().equals(itemId))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_ITEM_NOT_FOUND));
+
+        if (targetInventory.isEquipped()) {
+            throw new CustomException(ErrorCode.E_409_DONT_SELL_EQUIPPED_ITEM);
+        }
+
+        ItemDefMongo targetDef = itemDefMongoRepository.findById(itemId)
+                .orElseThrow(() -> new CustomException(ErrorCode.E_404_ITEM_NOT_FOUND));
+
+        playerGold = playerGold + targetDef.getPrice();
+
+        inventory.remove(targetInventory);
+        playerInfo.setGold(playerGold);
+
+        gameSessionMongo.setInventory(inventory);
+        gameSessionMongo.setPlayerInfo(playerInfo);
 
         return gameSessionMongoRepository.save(gameSessionMongo);
     }


### PR DESCRIPTION
## 📑 기능 설명
게임 내 선택지 중 "SHOP" 유형을 생성하는 기능을 구현합니다.  
플레이어가 특정 이벤트에서 상점을 방문할 수 있도록 하며, 해당 선택지를 선택 시 상점 UI 및 아이템 구매 기능으로 연결됩니다.  

## ✅ 작업할 내용
- [x] 선택지 타입에 `SHOP` 추가 (ENUM or 상수 정의)
- [x] SHOP 선택지 생성 로직 구현
- [x] SHOP 선택 시 상점 아이템 목록 API 호출 연동
- [x] 선택지 응답 DTO에 SHOP 관련 정보 포함
- [x] 유닛 테스트 작성
- [x] 구매 시 중복구매 체크
- [x] 구매 시 금액체크
- [x] 판매 시 장착아이템 예외처리

## 🎈 기대 효과
- 플레이어가 스토리 진행 중 상점 방문 가능
- 상점/아이템 구매 기능과 선택지 시스템 통합
- 아이템 구매/판매 기능도 추가

## 📎 추가 정보
- 선택지 응답 예시:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 게임 세션 상점 기능 추가: 아이템 구매/판매 지원 및 상점 화면 데이터 제공(플레이어, NPC, 인벤토리, 상점 아이템 목록).
  - 상점 아이템 목록에 효과/능력치/가격 등 상세 정보 표시.
  - 상황별 안내/오류 메시지 추가: 금액 부족, 부적합한 위치, 장착 아이템 판매 불가, 이미 판매된 아이템.
- Refactor
  - 게임 진행 확률 조정: 상점 등장 빈도 대폭 상향, 전투/선택/종료 비율 축소.
- Bug Fixes
  - 선택 처리 흐름의 보상 변수 초기화로 잠재적 초기화 문제 예방.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->