### PR TITLE
Feature/177 implement swagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.4'
+	id 'org.springframework.boot' version '3.3.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -63,6 +63,7 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+	implementation 'org.apache.commons:commons-lang3:3.18.0'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
 	// 소셜 로그인 oauth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/scriptopia/demo/config/JwtAuthFilter.java
+++ b/src/main/java/com/scriptopia/demo/config/JwtAuthFilter.java
@@ -49,13 +49,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 Arrays.stream(SecurityWhitelist.PUBLIC_GETS)
                         .anyMatch(pattern -> pathMatcher.match(pattern, path));
 
-        boolean skip = authMatch || publicGetMatch;
-
-        if (skip) {
-            log.debug("➡️ Skipping JwtAuthFilter for whitelisted request: {} {}", method, path);
-        }
-
-        return skip;
+        return authMatch || publicGetMatch;
     }
 
 

--- a/src/main/java/com/scriptopia/demo/config/LocalDataSeeder.java
+++ b/src/main/java/com/scriptopia/demo/config/LocalDataSeeder.java
@@ -57,11 +57,9 @@ public class LocalDataSeeder implements ApplicationRunner {
     @Override
     @Transactional
     public void run(ApplicationArguments args) {
-        log.info("=== LocalDataSeeder: start ===");
 
         // 0) 이미 데이터가 있으면 중복 시드 방지
         if (userRepository.count() > 1) {
-            log.info("Users already exist. Skip seeding.");
             return;
         }
 

--- a/src/main/java/com/scriptopia/demo/config/SecurityWhitelist.java
+++ b/src/main/java/com/scriptopia/demo/config/SecurityWhitelist.java
@@ -15,7 +15,12 @@ public class SecurityWhitelist {
 
             "/oauth/**",
 
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+
             "/shops/pia/items"
+
+
 
 
     };

--- a/src/main/java/com/scriptopia/demo/config/SwaggerConfig.java
+++ b/src/main/java/com/scriptopia/demo/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.scriptopia.demo.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI OpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Scriptopia API").version("1.0"))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .components(new io.swagger.v3.oas.models.Components()
+                        .addSecuritySchemes("bearerAuth",
+                                new SecurityScheme()
+                                        .name("bearerAuth")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        )
+                );
+    }
+
+    private Info ApiInfo() {
+        return new Info()
+                .title("Scriptopia Swagger")
+                .description("Scriptopia 공식 API 문서입니다.")
+                .version("1.0.0");
+
+    }
+}

--- a/src/main/java/com/scriptopia/demo/config/SwaggerExampleConfig.java
+++ b/src/main/java/com/scriptopia/demo/config/SwaggerExampleConfig.java
@@ -1,0 +1,44 @@
+package com.scriptopia.demo.config;
+
+import com.scriptopia.demo.dto.auth.LoginRequest;
+import io.swagger.v3.oas.models.examples.Example;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerExampleConfig {
+
+
+    @Value("${app.admin.username}")
+    private String adminUsername;
+
+    @Value("${app.admin.password}")
+    private String adminPassword;
+
+
+    @Bean
+    public OpenApiCustomizer customiseExamples() {
+        return openApi -> {
+            if (openApi.getPaths() == null) return;
+
+            openApi.getPaths().forEach((path, item) -> {
+                if (path.endsWith("/auth/login") && item.getPost() != null) {
+                    var reqBody = item.getPost().getRequestBody();
+                    if (reqBody == null) return;
+
+                    var content = reqBody.getContent().get("application/json");
+                    if (content == null) return;
+
+                    // DTO 객체 그대로 넣기
+                    content.addExamples("어드민 계정",
+                            new Example().value(new LoginRequest(adminUsername, adminPassword, "1234")));
+
+                    content.addExamples("일반 유저 계정",
+                            new Example().value(new LoginRequest("userA@example.com", "userA!234", "1234")));
+                }
+            });
+        };
+    }
+}

--- a/src/main/java/com/scriptopia/demo/controller/AuctionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuctionController.java
@@ -3,6 +3,8 @@ package com.scriptopia.demo.controller;
 
 import com.scriptopia.demo.dto.auction.*;
 import com.scriptopia.demo.service.AuctionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -11,11 +13,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "거래 API", description = "경매장 관련 거래 API 입니다.")
 @RequestMapping("/trades")
 public class AuctionController {
 
     private final AuctionService auctionService;
 
+    @Operation(summary = "보유 장비 아이템 조회")
     @GetMapping
     public ResponseEntity<TradeResponse> getTrades(
             @RequestBody TradeFilterRequest requestDto) {
@@ -25,6 +29,7 @@ public class AuctionController {
 
     }
 
+    @Operation(summary = "경매장 아이템 구매")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/{auctionId}/purchase")
     public ResponseEntity<String> purchaseItem(
@@ -37,6 +42,7 @@ public class AuctionController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "내가 등록한 판매 아이템 조회")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/me")
     public ResponseEntity<MySaleItemResponse> mySaleItems(
@@ -49,6 +55,7 @@ public class AuctionController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "경매장 아이템 판매 등록")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping
     public ResponseEntity<String> createAuction(@RequestBody AuctionRequest dto,
@@ -58,6 +65,7 @@ public class AuctionController {
         return ResponseEntity.ok(auctionService.createAuction(dto, userId));
     }
 
+    @Operation(summary = "판매 중인 아이템 등록 취소")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @DeleteMapping("/{auctionId}")
     public ResponseEntity<String> cancelMySaleItem(
@@ -69,6 +77,7 @@ public class AuctionController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "내 거래 기록 조회(정산 테이블 조회)")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/me/history")
     public ResponseEntity<SettlementHistoryResponse> settlementHistory(
@@ -81,6 +90,7 @@ public class AuctionController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "구매 아이템/판매 대금 수령")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/{settlementId}/confirm")
     public ResponseEntity<String> confirmItem(

--- a/src/main/java/com/scriptopia/demo/controller/AuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/AuthController.java
@@ -3,6 +3,8 @@ package com.scriptopia.demo.controller;
 import com.scriptopia.demo.dto.auth.*;
 import com.scriptopia.demo.service.LocalAccountService;
 import com.scriptopia.demo.service.RefreshTokenService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -15,17 +17,17 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
+@Tag(name = "로컬 인증 API", description = "로컬 인증 관련 API 입니다.")
 @RequiredArgsConstructor
 public class AuthController {
     private final LocalAccountService localAccountService;
     private final RefreshTokenService refreshTokenService;
-
     private static final String RT_COOKIE = "RT";
     private static final boolean COOKIE_SECURE = true;
     private static final String COOKIE_SAMESITE = "None";
 
 
-
+    @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public ResponseEntity<?> logout(
             @CookieValue(name = RT_COOKIE, required = false) String refreshToken,
@@ -38,7 +40,7 @@ public class AuthController {
         return ResponseEntity.ok("로그아웃 되었습니다.");
     }
 
-
+    @Operation(summary = "로컬 로그인")
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(
             @RequestBody @Valid LoginRequest req,
@@ -49,6 +51,7 @@ public class AuthController {
         return ResponseEntity.ok(localAccountService.login(req, request, response));
     }
 
+    @Operation(summary = "로컬 계정 회원가입")
     @PostMapping("/register")
     public ResponseEntity<?> register(
             @RequestBody @Valid RegisterRequest request
@@ -57,6 +60,7 @@ public class AuthController {
         return ResponseEntity.ok("회원가입에 성공했습니다.");
     }
 
+    @Operation(summary = "이메일 중복 검증")
     @PostMapping("/email/verify")
     public ResponseEntity<?> verifyEmail(@Valid @RequestBody VerifyEmailRequest request) {
 
@@ -65,21 +69,21 @@ public class AuthController {
         return ResponseEntity.ok("사용 가능한 이메일입니다.");
     }
 
-
+    @Operation(summary = "이메일 인증 코드 전송")
     @PostMapping("/email/code/send")
     public ResponseEntity<String> sendCode(@RequestBody @Valid SendCodeRequest request) {
         localAccountService.sendVerificationCode(request.getEmail());
         return ResponseEntity.ok("인증 코드가 이메일로 발송되었습니다.");
     }
 
+    @Operation(summary = "이메일 인증 코드 확인")
     @PostMapping("/email/code/verify")
     public ResponseEntity<String> verifyCode(@RequestBody @Valid VerifyCodeRequest request) {
         localAccountService.verifyCode(request.getEmail(), request.getCode());
         return ResponseEntity.ok("이메일 인증이 완료되었습니다.");
-
     }
 
-
+    @Operation(summary = "비밀번호 초기화 링크 발송")
     @PostMapping("/password/reset/send")
     public ResponseEntity<?> sendResetMail(@Valid @RequestBody SendCodeRequest request){
 
@@ -88,7 +92,7 @@ public class AuthController {
         return ResponseEntity.ok("비밀번호 초기화 링크를 전송했습니다.");
     }
 
-
+    @Operation(summary = "비밀번호 초기화")
     @PatchMapping("/password/reset")
     public ResponseEntity<?> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
         localAccountService.resetPassword(request.getToken(), request.getNewPassword());
@@ -96,7 +100,7 @@ public class AuthController {
         return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
     }
 
-
+    @Operation(summary = "비밀번호 재설정")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PatchMapping("/password/change")
     public ResponseEntity<String> changePassword(@RequestBody @Valid ChangePasswordRequest request,

--- a/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
+++ b/src/main/java/com/scriptopia/demo/controller/GameSessionController.java
@@ -6,6 +6,8 @@ import com.scriptopia.demo.domain.mongo.GameSessionMongo;
 import com.scriptopia.demo.dto.gamesession.*;
 import com.scriptopia.demo.service.GameSessionService;
 import com.scriptopia.demo.service.HistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/games")
+@Tag(name = "게임 세션 API", description = "게임 세션 관련 API 입니다.")
 @RequiredArgsConstructor
 public class GameSessionController {
 
@@ -23,6 +26,7 @@ public class GameSessionController {
     /*
      * 게임 -> 게임 도중 종료
      */
+    @Operation(summary = "저장 후 게임 종료")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("/exit")
     public ResponseEntity<?> createGameSession(Authentication authentication, @RequestBody GameSessionRequest request) {
@@ -33,15 +37,26 @@ public class GameSessionController {
     /*
      * 게임 -> 기존 게임 삭제
      */
+    @Operation(summary = "기존 게임 삭제")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @DeleteMapping()
     public ResponseEntity<?> deleteGameSession(Authentication authentication, @RequestBody GameSessionRequest request) {
         Long userId = Long.valueOf(authentication.getName());
         return gameSessionService.deleteGameSession(userId, request.getGameId());
     }
-    
-    
+
+    /*
+     * 게임 -> 기존 게임 조회
+     */
+    @Operation(summary = "기존 게임 조회")
+    @GetMapping("/me")
+    public ResponseEntity<?> loadGameSession(Authentication authentication) {
+        Long userId = Long.valueOf(authentication.getName());
+        return gameSessionService.getGameSession(userId);
+    }
+
     // 게임 시작
+    @Operation(summary = "새 게임 생성")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping
     public ResponseEntity<StartGameResponse> startNewGame(
@@ -54,7 +69,7 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
-
+    @Operation(summary = "게임 진입")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/{gameId}")
     public ResponseEntity<?> getInGameData(
@@ -69,20 +84,7 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
-
-    @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
-    @PostMapping("/{gameId}/progress")
-    public ResponseEntity<GameSessionMongo> keepGame(
-            @PathVariable("gameId") String gameId,
-            Authentication authentication) throws JsonProcessingException {
-
-        Long userId = Long.valueOf(authentication.getName());
-
-        GameSessionMongo response = gameSessionService.gameProgress(userId);
-        return ResponseEntity.ok(response);
-    }
-
-
+    @Operation(summary = "선택지 선택")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/{gameId}/select")
     public ResponseEntity<GameSessionMongo> selectChoice(
@@ -97,6 +99,21 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "게임 진행")
+    @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
+    @PostMapping("/{gameId}/progress")
+    public ResponseEntity<GameSessionMongo> keepGame(
+            @PathVariable("gameId") String gameId,
+            Authentication authentication) throws JsonProcessingException {
+
+        Long userId = Long.valueOf(authentication.getName());
+
+        GameSessionMongo response = gameSessionService.gameProgress(userId);
+        return ResponseEntity.ok(response);
+    }
+
+
+    @Operation(summary = "아이템 장착/해제")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/equipItem/{gameId}/{itemId}")
     public ResponseEntity<GameSessionMongo> equipItem(
@@ -111,6 +128,7 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "아이템 버리기")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @DeleteMapping("/dropItem/{gameId}/{itemId}")
     public ResponseEntity<GameSessionMongo> dropItem(
@@ -125,6 +143,7 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "아이템 구매")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/{gameId}/items/purchase/{itemId}")
     public ResponseEntity<GameSessionMongo> buyItem(
@@ -139,6 +158,7 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "아이템 판매")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/{gameId}/items/sell/{itemId}")
     public ResponseEntity<GameSessionMongo> sellItem(
@@ -153,17 +173,6 @@ public class GameSessionController {
         return ResponseEntity.ok(response);
     }
 
-    /*
-     * 게임 -> 기존 게임 조회
-     */
-    @GetMapping("/me")
-    public ResponseEntity<?> loadGameSession(Authentication authentication) {
-        Long userId = Long.valueOf(authentication.getName());
-        return gameSessionService.getGameSession(userId);
-    }
-
-
-
     /**
      * 현재는 userId, sessionId를 통해 저장하는데
      * 인증 관리 부분 끝나면 header에 token 꺼내오고 requestparameter session_id로 저장하게 수정
@@ -171,6 +180,7 @@ public class GameSessionController {
     /*
      * 게임 -> 히스토리 생성
      */
+    @Operation(summary = "")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("/history")
     public ResponseEntity<?> addHistory(Authentication authentication, @RequestBody GameSessionRequest request) {
@@ -179,6 +189,7 @@ public class GameSessionController {
     }
 
     /** 개발용: 로컬 MongoDB에 더미 세션 한 건 심어서 테스트용 ObjectId 반환 */
+    @Operation(summary = "")
     @PostMapping("/history/seed")
     public ResponseEntity<?> seed(Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());

--- a/src/main/java/com/scriptopia/demo/controller/ItemController.java
+++ b/src/main/java/com/scriptopia/demo/controller/ItemController.java
@@ -3,6 +3,8 @@ package com.scriptopia.demo.controller;
 import com.scriptopia.demo.dto.items.ItemDTO;
 import com.scriptopia.demo.dto.items.ItemDefRequest;
 import com.scriptopia.demo.service.ItemService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -11,12 +13,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/items")
+@Tag(name = "아이템 관련 API", description = "아이템 관련 API 입니다.")
 @RequiredArgsConstructor
 public class ItemController {
 
     private final ItemService itemService;
 
-
+    @Operation(summary = "어드민 테스트용 아이템 생성")
     @PreAuthorize("hasAnyAuthority('ADMIN')")
     @PostMapping
     public ResponseEntity<ItemDTO> createItem(

--- a/src/main/java/com/scriptopia/demo/controller/OAuthController.java
+++ b/src/main/java/com/scriptopia/demo/controller/OAuthController.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.scriptopia.demo.dto.oauth.OAuthLoginResponse;
 import com.scriptopia.demo.dto.oauth.SocialSignupRequest;
 import com.scriptopia.demo.service.OAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -12,16 +14,19 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/oauth")
+@Tag(name = "소셜 인증 관련 API", description = "소셜 인증 관련 API 입니다.")
 @RequiredArgsConstructor
 public class OAuthController {
 
     private final OAuthService oAuthService;
 
+    @Operation(summary = "Oauth 로그인 url 발급")
     @GetMapping("/authorize")
     public ResponseEntity<String> getAuthorizationUrl(@RequestParam("provider") String provider) {
         return ResponseEntity.ok(oAuthService.buildAuthorizationUrl(provider));
     }
 
+    @Operation(summary = "소셜 로그인")
     @GetMapping("/{provider}")
     public ResponseEntity<OAuthLoginResponse> login(
             @PathVariable("provider") String provider,
@@ -32,7 +37,7 @@ public class OAuthController {
         OAuthLoginResponse result = oAuthService.login(provider, code, request, response);
         return ResponseEntity.ok(result);
     }
-
+    @Operation(summary = "소셜 회원가입")
     @PostMapping("/register")
     public ResponseEntity<OAuthLoginResponse> signup(
             @RequestBody SocialSignupRequest req,

--- a/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
+++ b/src/main/java/com/scriptopia/demo/controller/PiaShopController.java
@@ -8,6 +8,8 @@ import com.scriptopia.demo.dto.piashop.PiaItemUpdateRequest;
 import com.scriptopia.demo.dto.piashop.PurchasePiaItemRequest;
 import com.scriptopia.demo.service.ItemService;
 import com.scriptopia.demo.service.PiaShopService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,11 +20,13 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "피아 상점 관련 API", description = "피아 상점 관련 API 입니다.")
 @RequestMapping("/shops")
 public class PiaShopController {
     private final PiaShopService piaShopService;
     private final ItemService itemService;
 
+    @Operation(summary = "PIA 상품 등록")
     @PreAuthorize("hasAnyAuthority('ADMIN')")
     @PostMapping("/items/pia")
     public ResponseEntity<String> createPiaItem(@RequestBody PiaItemRequest request) {
@@ -30,7 +34,7 @@ public class PiaShopController {
         return ResponseEntity.ok("PIA 아이템이 등록되었습니다.");
     }
 
-
+    @Operation(summary = "PIA 상품 수정")
     @PreAuthorize("hasAnyAuthority('ADMIN')")
     @PutMapping("/items/pia/{itemId}")
     public ResponseEntity<String> updatePiaItem(
@@ -42,11 +46,13 @@ public class PiaShopController {
         return ResponseEntity.ok(result);
     }
 
+    @Operation(summary = "PIA 판매 상품 목록 조회")
     @GetMapping("/pia/items")
     public ResponseEntity<List<PiaItemResponse>> getPiaItems() {
         return ResponseEntity.ok(piaShopService.getPiaItems());
     }
 
+    @Operation(summary = "PIA 상품 구매")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/pia/purchase")
     public ResponseEntity<String> purchasePiaItem(
@@ -58,6 +64,7 @@ public class PiaShopController {
         return ResponseEntity.ok("PIA 아이템을 구매했습니다.");
     }
 
+    @Operation(summary = "아이템 모루 사용")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/pia/items/anvil")
     public ResponseEntity<ItemDTO> useItemAnvil(

--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -11,6 +11,8 @@ import com.scriptopia.demo.dto.sharedgame.SharedGameRequest;
 import com.scriptopia.demo.service.SharedGameFavoriteService;
 import com.scriptopia.demo.service.SharedGameService;
 import com.scriptopia.demo.service.TagDefService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,6 +24,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/shared-games")
+@Tag(name = "게임 공유 관련 API", description = "게임 공유 관련 API 입니다.")
 @RequiredArgsConstructor
 public class SharedGameController {
     private final SharedGameService sharedGameService;
@@ -31,6 +34,8 @@ public class SharedGameController {
     /*
     게임 공유 -> 게임 공유하기
      */
+
+    @Operation(summary = "게임 공유하기")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping
     public ResponseEntity<?> share(Authentication authentication, @RequestBody SharedGameRequest req) {
@@ -42,6 +47,7 @@ public class SharedGameController {
     /*
     게임 공유 -> 공유 게임 목록 조회
      */
+    @Operation(summary = "공유 게임 목록 조회")
     @GetMapping
     public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
                                                                                      @RequestParam(required = false) UUID lastUUID,
@@ -56,6 +62,7 @@ public class SharedGameController {
     /*
     게임공유 : 공유된 게임 상세 조회
      */
+    @Operation(summary = "공유 게임 상세 조회")
     @GetMapping("/{sharedGameId}")
     public ResponseEntity<?> getSharedGameDetail(@PathVariable("sharedGameId") UUID sharedGameId) {
         return sharedGameService.getDetailedSharedGame(sharedGameId);
@@ -64,6 +71,7 @@ public class SharedGameController {
     /*
     게임공유 : 공유 게임 Like 요청
      */
+    @Operation(summary = "공유 게임 Like 요청")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("{sharedGameId}/like")
     public ResponseEntity<?> likeSharedGame(@PathVariable("sharedGameId") UUID sharedGameId, Authentication authentication) {
@@ -75,6 +83,7 @@ public class SharedGameController {
     /*
     게임공유 : 공유된 게임 태그 조회
      */
+    @Operation(summary = "게임 태그 조회")
     @GetMapping("/tags")
     public ResponseEntity<?> getSharedGameTags() {
         return sharedGameService.getTag();
@@ -83,6 +92,7 @@ public class SharedGameController {
     /*
     게임 공유 -> 공유한 게임 삭제
      */
+    @Operation(summary = "공유한 게임 삭제")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @DeleteMapping("/shared-games")
     public ResponseEntity<?> delete(Authentication authentication, @RequestBody SharedGameRequest req) {
@@ -96,6 +106,7 @@ public class SharedGameController {
     /*
     게임 공유 -> 공유한 게임 조회(내가 공유한 게임 조회)
      */
+    @Operation(summary = "(내가)공유한 게임 조회")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @GetMapping("/me")
     public ResponseEntity<?> getMySharedGames(Authentication authentication) {
@@ -104,6 +115,7 @@ public class SharedGameController {
         return sharedGameService.getMySharedGames(userId);
     }
 
+    @Operation(summary = "게임 태그 생성")
     @PreAuthorize("hasAnyAuthority('ADMIN')")
     @PostMapping("/tags")
     public ResponseEntity<?> addTag(@RequestBody TagDefCreateRequest req) {
@@ -111,6 +123,7 @@ public class SharedGameController {
         return tagDefService.addTagName(req);
     }
 
+    @Operation(summary = "게임 태그 삭제 ")
     @PreAuthorize("hasAnyAuthority('ADMIN')")
     @DeleteMapping("/tags")
     public ResponseEntity<?> removeTag(@RequestBody TagDefDeleteRequest req) {

--- a/src/main/java/com/scriptopia/demo/controller/TestEnvController.java
+++ b/src/main/java/com/scriptopia/demo/controller/TestEnvController.java
@@ -1,5 +1,6 @@
 package com.scriptopia.demo.controller;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 
 @Controller
+@Tag(name = "백엔드 정적 페이지 관련 API", description = "백엔드 정적 페이지 관련 API 입니다.")
 public class TestEnvController {
     @GetMapping("/")
     public String mainPage() {

--- a/src/main/java/com/scriptopia/demo/controller/UserController.java
+++ b/src/main/java/com/scriptopia/demo/controller/UserController.java
@@ -8,6 +8,8 @@ import com.scriptopia.demo.dto.users.UserSettingsDTO;
 import com.scriptopia.demo.service.HistoryService;
 import com.scriptopia.demo.service.UserCharacterImgService;
 import com.scriptopia.demo.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +23,7 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/users/me")
+@Tag(name = "유저 관련 API", description = "유저 관련 API 입니다.")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -28,6 +31,7 @@ public class UserController {
     private final HistoryService historyService;
     private final UserCharacterImgService userCharacterImgService;
 
+    @Operation(summary = "보유 장비 아이템 조회")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/items/game")
     public ResponseEntity<List<ItemDTO>> getGameItems(
@@ -38,6 +42,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "보유 피아 아이템 조회")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/items/pia")
     public ResponseEntity<List<PiaItemDTO>> getPiaItems(
@@ -48,6 +53,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "사용자 옵션 조회")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/settings")
     public ResponseEntity<UserSettingsDTO> getUserSettings(
@@ -58,6 +64,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "사용자 옵션 변경")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PutMapping("/settings")
     public ResponseEntity<String> updateUserSettings(
@@ -69,6 +76,7 @@ public class UserController {
         return ResponseEntity.ok("사용자 설정이 변경되었습니다.");
     }
 
+    @Operation(summary = "사용자 재화 조회")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @GetMapping("/assets")
     public ResponseEntity<UserAssetsResponse> getUserAssets(
@@ -79,6 +87,7 @@ public class UserController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "사용자 게임 기록 조회")
     @GetMapping("/games/histories")
     public ResponseEntity<List<HistoryPageResponse>> getHistory(@RequestParam(required = false) UUID lastId,
                                                                 @RequestParam(defaultValue = "10") int size,
@@ -88,6 +97,7 @@ public class UserController {
         return historyService.fetchMyHistory(userId, lastId, size);
     }
 
+    @Operation(summary = "프로필 이미지 변경")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("/profile-images/url")
     public ResponseEntity<?> saveUserCharacterImg(Authentication authentication, @RequestParam("url") String url) {
@@ -96,6 +106,7 @@ public class UserController {
         return userCharacterImgService.saveUserCharacterImg(userId, url);
     }
 
+    @Operation(summary = "프로필 등록할 수 있는 이미지 조회")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @GetMapping("/images")
     public ResponseEntity<?> getUserCharacterImgs(Authentication authentication) {
@@ -107,6 +118,7 @@ public class UserController {
     /*
     등록할 수 있는 이미지 저장
     */
+    @Operation(summary = "등록할 수 있는 이미지 저장")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("/save/img")
     public ResponseEntity<?> saveCharacterImg(Authentication authentication, @RequestParam("file") MultipartFile file) {

--- a/src/main/java/com/scriptopia/demo/controller/refreshController.java
+++ b/src/main/java/com/scriptopia/demo/controller/refreshController.java
@@ -7,6 +7,8 @@ import com.scriptopia.demo.dto.token.RefreshRequest;
 import com.scriptopia.demo.service.LocalAccountService;
 import com.scriptopia.demo.service.RefreshTokenService;
 import com.scriptopia.demo.utils.JwtProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
@@ -19,6 +21,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/token")
+@Tag(name = "리프레쉬 토큰 관련 API", description = "리프레쉬 토큰 관련 API 입니다.")
 @RequiredArgsConstructor
 public class refreshController {
 
@@ -31,6 +34,7 @@ public class refreshController {
     private static final boolean COOKIE_SECURE = true;
     private static final String COOKIE_SAMESITE = "None";
 
+    @Operation(summary = "리프레시 토큰 재발급")
     @PreAuthorize("hasAnyAuthority('USER','ADMIN')")
     @PostMapping("/refresh")
     public ResponseEntity<RefreshResponse> refresh(

--- a/src/main/java/com/scriptopia/demo/dto/auth/LoginRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/auth/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.scriptopia.demo.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -13,12 +14,15 @@ public class LoginRequest {
 
     @NotBlank(message = "E_400_MISSING_EMAIL")
     @Email(message = "E_400_INVALID_EMAIL_FORMAT")
+    @Schema(description = "사용자 아이디", example = "userA@example.com")
     private String email;
 
     @NotBlank(message = "E_400_MISSING_PASSWORD")
+    @Schema(description = "비밀번호", example = "userA!234")
     private String password;
 
     @NotBlank(message = "디바이스 식별값이 필요합니다.")
+    @Schema(description = "디바이스 아이디", example = "1234")
     private String deviceId;
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,8 @@ oauth:
     redirect-uri: ${NAVER_REDIRECT_URI}
     scope: name email profile_image
 
+
+
 auth:
   jwt:
     issuer: scriptopia
@@ -68,6 +70,15 @@ app:
   admin:
     username: ${ADMIN_NAME}
     password: ${ADMIN_PASSWORD}
+
+server:
+  servlet:
+    context-path: /api/v1
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui
 
 image-dir: ./uploads/
 image-url-prefix: /images


### PR DESCRIPTION
## 🚀 관련 이슈

Close #177 

## 📑 PR 설명

## ✏️ 작업 내용

## ✅ 체크리스트

- [x] 로컬에서 정상 동작 확인
- [x] 빌드 통과 확인
- [x] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - Swagger/OpenAPI 문서와 UI 제공, JWT Bearer 인증 연동 및 로그인 예시 자동 삽입.
  - 게임 세션 관련 신규 엔드포인트 추가(내 세션 조회, 장비 착용/버리기/구매/판매), 공유 게임 태그 추가/삭제 제공.
  - 기본 API 컨텍스트 경로를 /api/v1로 설정.

- 변경
  - 일부 엔드포인트가 인증 컨텍스트를 요구하도록 서명 조정, 일부 경로 정리(선택/진행).

- 문서
  - 다수 컨트롤러에 Tag/Operation 주석 및 DTO 필드 예시 추가.

- 작업
  - 빌드 플러그인 버전 조정, 문서/유틸 의존성 추가, 문서 경로 화이트리스트 및 설정 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->