### PR TITLE
[Refactor] 공유게임 반환 UUID 변경

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -49,14 +49,12 @@ public class SharedGameController {
      */
     @Operation(summary = "공유 게임 목록 조회")
     @GetMapping
-    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Authentication authentication,
-                                                                                     @RequestParam(required = false) UUID lastUUID,
+    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(@RequestParam(required = false) UUID lastUUID,
                                                                                      @RequestParam(defaultValue = "20") int size,
                                                                                      @RequestParam(required = false) List<Long> tagIds,
                                                                                      @RequestParam(required = false) String query,
                                                                                      @RequestParam(defaultValue = "POPULAR")SharedGameSort sort) {
-        Long viewerId = (authentication == null) ? null : Long.valueOf(authentication.getName());
-        return sharedGameService.getPublicSharedGames(viewerId, lastUUID, size, tagIds, query, sort);
+        return sharedGameService.getPublicSharedGames(lastUUID, size, tagIds, query, sort);
     }
 
     /*

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
@@ -10,12 +10,13 @@ import java.util.UUID;
 @Data
 public class PublicSharedGameDetailResponse {
     private UUID sharedGameUUID;
-    private String nickname;
-    private String thumbnailUrl;
-    private Long totalPlayed;
+    private String posterUrl;
     private String title;
     private String worldView;
     private String backgroundStory;
+    private String creator;
+    private Long playCount;
+    private Long likeCount;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private LocalDateTime sharedAt;
@@ -24,9 +25,11 @@ public class PublicSharedGameDetailResponse {
 
     @Data
     public static class TagDto {
+        private Long tagId;
         private String tagName;
 
-        public TagDto(String tagName) {
+        public TagDto(Long tagId, String tagName) {
+            this.tagId = tagId;
             this.tagName = tagName;
         }
     }

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -99,25 +99,26 @@ public class SharedGameService {
         SharedGame game = sharedGameRepository.findByUuid(uuid)
                 .orElseThrow(() -> new CustomException(ErrorCode.E_404_SHARED_GAME_NOT_FOUND));
 
-        List<String> tagName = gameTagRepository.findTagNamesBySharedGameId(game.getId());
+        List<com.scriptopia.demo.dto.sharedgame.TagDto> tagDtos = gameTagRepository.findTagDtosBySharedGameId(game.getId());
 
         List<SharedGameScore> score = sharedGameScoreRepository.findAllBySharedGameIdOrderByScoreDescCreatedAtDesc(game.getId());
 
         PublicSharedGameDetailResponse dto = new PublicSharedGameDetailResponse();
         dto.setSharedGameUUID(game.getUuid());
-        dto.setNickname(game.getUser().getNickname());
-        dto.setThumbnailUrl(game.getThumbnailUrl());
-        dto.setTotalPlayed(sharedGameScoreRepository.countBySharedGameId(game.getId()));
+        dto.setPosterUrl(game.getThumbnailUrl());
         dto.setTitle(game.getTitle());
         dto.setWorldView(game.getWorldView());
         dto.setBackgroundStory(game.getBackgroundStory());
+        dto.setCreator(game.getUser().getNickname());
+        dto.setPlayCount(sharedGameScoreRepository.countBySharedGameId(game.getId()));
+        dto.setLikeCount(sharedGameFavoriteRepository.countBySharedGameId(game.getId()));
         dto.setSharedAt(game.getSharedAt());
 
         List<PublicSharedGameDetailResponse.TagDto> tagarray = new ArrayList<>();
         List<PublicSharedGameDetailResponse.TopScoreDto> topscorearray = new ArrayList<>();
 
-        for(var tagNames : tagName) {
-            tagarray.add(new PublicSharedGameDetailResponse.TagDto(tagNames));
+        for(var tagDto : tagDtos) {
+            tagarray.add(new PublicSharedGameDetailResponse.TagDto(tagDto.getTagId(), tagDto.getTagName()));
         }
 
         dto.setTags(tagarray);
@@ -146,7 +147,7 @@ public class SharedGameService {
     }
 
     @Transactional(readOnly = true)
-    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(Long userId,
+    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(
                                                                                UUID lastUuid,
                                                                                int size,
                                                                                List<Long> tagIds,
@@ -221,12 +222,6 @@ public class SharedGameService {
 
             Long topScore = sharedGameScoreRepository.maxScoreBySharedGameId(g.getId());
             dto.setTopScore(topScore == null ? 0L : topScore);
-
-            // 좋아요 여부
-            if (userId != null) {
-                boolean liked = sharedGameFavoriteRepository.existsByUserIdAndSharedGameId(userId, g.getId());
-                dto.setLiked(liked);
-            }
 
             // 태그
             dto.setTags(gameTagRepository.findTagDtosBySharedGameId(g.getId()));


### PR DESCRIPTION
## 🚀 관련 이슈

Close #190 

## 📑 PR 설명
공유게임 UUID로 변경, DTO 변환 변수 이름 변경, 공유 게임 세부 조회에서 tagId 누락 -> 추가

## ✏️ 작업 내용
DTO, service 수정

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 공개 공유 게임 목록에 태그/검색어 필터, 정렬 옵션(기본: 인기), 커서 기반 페이지네이션(lastUUID, size 기본 20) 추가
- 변경사항
  - 상세 보기 정보 개편: 포스터 이미지, 제작자, 플레이 수, 좋아요 수 표시로 업데이트
  - 기존 닉네임, 썸네일, 총 플레이 수 항목을 대체
  - 공개 목록에서 사용자별 ‘좋아요 여부’ 표시는 제거
  - 인증 없이 공개 목록 접근 가능 (요청 파라미터만으로 조회)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->