### PR TITLE
[Refactor] 공유게임 반환 UUID 변경

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -49,11 +49,11 @@ public class SharedGameController {
      */
     @Operation(summary = "공유 게임 목록 조회")
     @GetMapping
-    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(@RequestParam(required = false) UUID lastUUID,
-                                                                                     @RequestParam(defaultValue = "20") int size,
-                                                                                     @RequestParam(required = false) List<Long> tagIds,
-                                                                                     @RequestParam(required = false) String query,
-                                                                                     @RequestParam(defaultValue = "POPULAR")SharedGameSort sort) {
+    public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(@RequestParam(value = "lastUUID", required = false) UUID lastUUID,
+                                                                                     @RequestParam(value = "size", defaultValue = "20") int size,
+                                                                                     @RequestParam(value = "tagIds", required = false) List<Long> tagIds,
+                                                                                     @RequestParam(value = "query", required = false) String query,
+                                                                                     @RequestParam(value = "sort", defaultValue = "POPULAR") SharedGameSort sort) {
         return sharedGameService.getPublicSharedGames(lastUUID, size, tagIds, query, sort);
     }
 

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/CursorPage.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/CursorPage.java
@@ -3,4 +3,4 @@ package com.scriptopia.demo.dto.sharedgame;
 import java.util.List;
 import java.util.UUID;
 
-public record CursorPage<T>(List<T> items, UUID nextCursor, boolean hasNext) {}
+public record CursorPage<T>(List<T> items, UUID lastUuid, boolean hasNextPage) {}

--- a/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
+++ b/src/main/java/com/scriptopia/demo/repository/SharedGameScoreRepository.java
@@ -2,15 +2,15 @@ package com.scriptopia.demo.repository;
 
 import com.scriptopia.demo.domain.SharedGame;
 import com.scriptopia.demo.domain.SharedGameScore;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface SharedGameScoreRepository extends JpaRepository<SharedGameScore, Long> {
     @Query("Select count(s) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
-    long countBySharedGameId(Long sharedGameId);
+    long countBySharedGameId(@Param("sharedGameId") Long sharedGameId);
 
     @Query("select coalesce(max(s.score), 0) from SharedGameScore s where s.sharedGame.id = :sharedGameId")
     Long maxScoreBySharedGameId(@Param("sharedGameId") Long sharedGameId);


### PR DESCRIPTION
## 🚀 관련 이슈

Close #194 

## 📑 PR 설명
공유 게임 UUID cursor DTO 수정

## ✏️ 작업 내용

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 페이징 응답 스키마가 업데이트되었습니다: nextCursor → lastUuid, hasNext → hasNextPage로 필드명이 변경되었습니다. API 클라이언트는 응답 필드 참조를 업데이트해야 합니다.
- Bug Fixes
  - 공개 공유 게임 목록 조회 시 쿼리 파라미터(lastUUID, size, tagIds, query, sort) 바인딩을 개선하여 파라미터 파싱 일관성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->