### PR TITLE
[Feature] 프로필 이미지 변경(parameter -> body)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 
+/docker_compose_file/.env
 /docker_compose_files/data
 /docker_compose_files/mongo_data
 /docker_compose_files/postgres_data

--- a/src/main/java/com/scriptopia/demo/controller/UserController.java
+++ b/src/main/java/com/scriptopia/demo/controller/UserController.java
@@ -4,6 +4,7 @@ import com.scriptopia.demo.dto.history.HistoryPageResponse;
 import com.scriptopia.demo.dto.items.ItemDTO;
 import com.scriptopia.demo.dto.users.PiaItemDTO;
 import com.scriptopia.demo.dto.users.UserAssetsResponse;
+import com.scriptopia.demo.dto.users.UserImageRequest;
 import com.scriptopia.demo.dto.users.UserSettingsDTO;
 import com.scriptopia.demo.service.UserCharacterImgService;
 import com.scriptopia.demo.service.UserService;
@@ -97,10 +98,10 @@ public class UserController {
     @Operation(summary = "프로필 이미지 변경")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
     @PostMapping("/profile-images")
-    public ResponseEntity<?> saveUserCharacterImg(Authentication authentication, @RequestParam("url") String url) {
+    public ResponseEntity<?> saveUserCharacterImg(Authentication authentication, @RequestBody UserImageRequest req) {
         Long userId = Long.valueOf(authentication.getName());
 
-        return userCharacterImgService.saveUserCharacterImg(userId, url);
+        return userCharacterImgService.saveUserCharacterImg(userId, req.getUrl());
     }
 
     @Operation(summary = "프로필 이미지 조회")

--- a/src/main/java/com/scriptopia/demo/dto/history/HistoryResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/history/HistoryResponse.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 
 @Builder
@@ -13,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class HistoryResponse {
-    private Long id;
+    private UUID uuid;
     private Long userId;
     private String thumbnailUrl;
     private String title;

--- a/src/main/java/com/scriptopia/demo/dto/users/UserImageRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/users/UserImageRequest.java
@@ -1,0 +1,12 @@
+package com.scriptopia.demo.dto.users;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor
+public class UserImageRequest {
+    private String url;
+}

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -1306,7 +1306,7 @@ public class GameSessionService {
 
 
         HistoryResponse historyResponse = HistoryResponse.builder()
-                .id(history.getId())
+                .uuid(history.getUuid())
                 .userId(user.getId())
                 .thumbnailUrl(history.getThumbnailUrl())
                 .title(history.getTitle())


### PR DESCRIPTION
## 🚀 관련 이슈

Close #196 

## 📑 PR 설명
프로필 이미지 변경 Controller parameter에서 -> body로 변경
GameSession Controller 에서 Id에서 Uuid로 변경

## ✏️ 작업 내용
GameController, UserController 변경

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Refactor
  * 프로필 이미지 저장 API 입력이 쿼리 파라미터(url)에서 요청 본문(JSON, url 필드)으로 변경되었습니다.
  * 기록 관련 응답의 식별자가 id에서 uuid로 대체되었습니다.
  * 기존 클라이언트는 요청/응답 스키마를 업데이트해야 하며, 기능은 동일하나 데이터 전달 방식과 필드명이 바뀌었습니다.

* Chores
  * Docker Compose용 환경 변수 파일(.env)을 버전 관리에서 제외했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->