### PR TITLE
[Refactor] 게임 공유하기 수정

### DIFF
--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -48,10 +48,10 @@ public class SharedGameController {
     @GetMapping
     public ResponseEntity<CursorPage<PublicSharedGameResponse>> getPublicSharedGames(@RequestParam(value = "lastUUID", required = false) UUID lastUUID,
                                                                                      @RequestParam(value = "size", defaultValue = "20") int size,
-                                                                                     @RequestParam(value = "tagIds", required = false) List<Long> tagIds,
+                                                                                     @RequestParam(value = "tags", required = false) List<Long> tags,
                                                                                      @RequestParam(value = "query", required = false) String query,
                                                                                      @RequestParam(value = "sort", defaultValue = "POPULAR") SharedGameSort sort) {
-        return sharedGameService.getPublicSharedGames(lastUUID, size, tagIds, query, sort);
+        return sharedGameService.getPublicSharedGames(lastUUID, size, tags, query, sort);
     }
 
     /*

--- a/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
+++ b/src/main/java/com/scriptopia/demo/controller/SharedGameController.java
@@ -77,8 +77,8 @@ public class SharedGameController {
      */
     @Operation(summary = "공유 게임 Like 요청")
     @PreAuthorize("hasAnyAuthority('USER', 'ADMIN')")
-    @PostMapping("{sharedGameUuId}/like")
-    public ResponseEntity<?> likeSharedGame(@PathVariable("sharedGameUuId") UUID sharedGameId, Authentication authentication) {
+    @PostMapping("{sharedGameUuid}/like")
+    public ResponseEntity<?> likeSharedGame(@PathVariable("sharedGameUuid") UUID sharedGameId, Authentication authentication) {
         Long userId = Long.valueOf(authentication.getName());
 
         return sharedGameFavoriteService.saveFavorite(userId, sharedGameId);

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
@@ -1,6 +1,7 @@
 package com.scriptopia.demo.dto.sharedgame;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -17,6 +18,8 @@ public class PublicSharedGameDetailResponse {
     private String creator;
     private Long playCount;
     private Long likeCount;
+
+    @JsonProperty("isLiked")
     private boolean isLiked;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameDetailResponse.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 @Data
 public class PublicSharedGameDetailResponse {
-    private UUID sharedGameUuID;
+    private UUID sharedGameUuid;
     private String posterUrl;
     private String title;
     private String worldView;

--- a/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/sharedgame/PublicSharedGameResponse.java
@@ -10,12 +10,8 @@ import java.util.UUID;
 public class PublicSharedGameResponse {
     private UUID sharedGameUuid;
     private String thumbnailUrl;
-    private boolean isLiked;
-    private Long likeCount;
-    private Long totalPlayCount;
     private String title;
-    private Long topScore;
-    private LocalDateTime sharedAt;
+    private Long playCount;
 
     private List<TagDto> tags;
 

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -58,41 +58,6 @@ public class SharedGameService {
         return ResponseEntity.ok(dto);
     }
 
-    public ResponseEntity<?> getMySharedGames(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.E_404_USER_NOT_FOUND));
-
-        List<SharedGame> games = sharedGameRepository.findAllByUserid(user.getId());
-
-        List<MySharedGameResponse> dtos = new ArrayList<>();
-
-        for(SharedGame game : games) {
-            MySharedGameResponse dto = new MySharedGameResponse();
-            dto.setShared_game_uuid(game.getUuid());
-            dto.setThumbnailUrl(game.getThumbnailUrl());
-            dto.setTotalPlayed(sharedGameScoreRepository.countBySharedGameId(game.getId()));
-            dto.setTitle(game.getTitle());
-            dto.setWorldView(game.getWorldView());
-            dto.setSharedAt(game.getSharedAt());
-            dto.setBackgroundStory(game.getBackgroundStory());
-
-            boolean liked = sharedGameFavoriteRepository.existsLikeSharedGame(user.getId(), game.getId());
-            dto.setRecommand(liked);
-
-            List<String> tagdto = gameTagRepository.findTagNamesBySharedGameId(game.getId());
-            List<MySharedGameResponse.TagDto> tags = new ArrayList<>();
-
-            for(String tagName : tagdto) {
-                tags.add(new MySharedGameResponse.TagDto(tagName));
-            }
-
-            dto.setTags(tags);
-            dtos.add(dto);
-        }
-
-        return ResponseEntity.ok(dtos);
-    }
-
     @Transactional
     public void deleteSharedGame(Long id, UUID uuid) {
         User user = userRepository.findById(id)
@@ -230,14 +195,9 @@ public class SharedGameService {
             dto.setSharedGameUuid(g.getUuid());
             dto.setThumbnailUrl(g.getThumbnailUrl());
             dto.setTitle(g.getTitle());
-            dto.setSharedAt(g.getSharedAt());
 
             // 집계
-            dto.setTotalPlayCount(sharedGameScoreRepository.countBySharedGameId(g.getId()));
-            dto.setLikeCount(sharedGameFavoriteRepository.countBySharedGameId(g.getId()));
-
-            Long topScore = sharedGameScoreRepository.maxScoreBySharedGameId(g.getId());
-            dto.setTopScore(topScore == null ? 0L : topScore);
+            dto.setPlayCount(sharedGameScoreRepository.countBySharedGameId(g.getId()));
 
             // 태그
             dto.setTags(gameTagRepository.findTagDtosBySharedGameId(g.getId()));

--- a/src/main/java/com/scriptopia/demo/service/SharedGameService.java
+++ b/src/main/java/com/scriptopia/demo/service/SharedGameService.java
@@ -83,7 +83,7 @@ public class SharedGameService {
         boolean isLiked = (userId != null) && sharedGameFavoriteRepository.existsByUserIdAndSharedGameId(userId, game.getId());
 
         PublicSharedGameDetailResponse dto = new PublicSharedGameDetailResponse();
-        dto.setSharedGameUuID(game.getUuid());
+        dto.setSharedGameUuid(game.getUuid());
         dto.setPosterUrl(game.getThumbnailUrl());
         dto.setTitle(game.getTitle());
         dto.setWorldView(game.getWorldView());


### PR DESCRIPTION
## 🚀 관련 이슈

Close #211 

## 📑 PR 설명

## ✏️ 작업 내용
게임 공유하기 API 수정, 형식 수정

## ✅ 체크리스트

- [ ] 로컬에서 정상 동작 확인
- [ ] 빌드 통과 확인
- [ ] 관련 문서 업데이트

## 📎 추가 정보

## 💬 리뷰 포인트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 공개 공유 게임 목록 API의 태그 필터 파라미터 이름을 tagIds에서 tags로 변경.
  - 좋아요 엔드포인트의 경로 변수를 sharedGameUuid로 통일해 일관성 개선.
  - 목록 응답 스키마 업데이트: isLiked, likeCount, totalPlayCount, topScore, sharedAt 제거하고 playCount 추가.
  - 상세 응답에서 식별자 필드를 sharedGameUuid로 정리하고 isLiked의 JSON 속성명을 명시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->