### PR TITLE
Feature/add story title on game complete 198

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 
+/docker_compose_files/.env
 /docker_compose_files/data
 /docker_compose_files/mongo_data
 /docker_compose_files/postgres_data

--- a/src/main/java/com/scriptopia/demo/config/fastapi/FastApiEndpoint.java
+++ b/src/main/java/com/scriptopia/demo/config/fastapi/FastApiEndpoint.java
@@ -6,7 +6,8 @@ public enum FastApiEndpoint {
     BATTLE("/games/battle"),
     ITEM("/games/item"),
     DONE("/games/done"),
-    END("/games/end");
+    END("/games/end"),
+    TITLE("/games/title");
 
     private final String path;
 

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleRequest.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -12,5 +14,5 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GameTitleRequest {
-    private List<String> contents;
+    private List<String> contents = new ArrayList<>();
 }

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleRequest.java
@@ -1,0 +1,15 @@
+package com.scriptopia.demo.dto.gamesession;
+
+import lombok.Data;
+import lombok.Builder;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GameTitleRequest {
+    private String content;
+}

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleRequest.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleRequest.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import lombok.Builder;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import java.util.List;
 
 
 @Data
@@ -11,5 +12,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class GameTitleRequest {
-    private String content;
+    private List<String> contents;
 }

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleResponse.java
@@ -4,11 +4,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.util.List;
 
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class GameTitleResponse {
-    private String title;
+    private List<String> titles;
 }

--- a/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleResponse.java
+++ b/src/main/java/com/scriptopia/demo/dto/gamesession/GameTitleResponse.java
@@ -1,0 +1,14 @@
+package com.scriptopia.demo.dto.gamesession;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class GameTitleResponse {
+    private String title;
+}

--- a/src/main/java/com/scriptopia/demo/service/FastApiService.java
+++ b/src/main/java/com/scriptopia/demo/service/FastApiService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class FastApiService {
@@ -74,5 +76,16 @@ public class FastApiService {
                 .bodyToMono(GameEndResponse.class)
                 .block();
     }
+
+    // 게임 종료 시 빅 이벤트 타이틀 처리
+    public GameTitleResponse title(GameTitleRequest request) {
+        return fastApiWebClient.post()
+                .uri(FastApiEndpoint.TITLE.getPath())
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(GameTitleResponse.class)
+                .block();
+    }
+
 
 }

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 @Service
@@ -1118,7 +1119,7 @@ public class GameSessionService {
         player.setIntelligence(player.getIntelligence() + safeStat(item.getIntelligence()));
         player.setLuck(player.getLuck() + safeStat(item.getLuck()));
         if (item.getCategory() == ItemType.ARMOR){
-            player.setLife( item.getBaseStat() );
+            player.setHealthPoint( item.getBaseStat() );
         }
     }
 
@@ -1288,6 +1289,7 @@ public class GameSessionService {
         HistoryInfoMongo historyInfoMongo = gameSessionMongo.getHistoryInfo();
 
         GameTitleRequest fastApiRequest = new GameTitleRequest();
+
         if(historyInfoMongo.getBackgroundStory() != null){
             fastApiRequest.getContents().add(historyInfoMongo.getBackgroundStory());
         }
@@ -1301,15 +1303,15 @@ public class GameSessionService {
             fastApiRequest.getContents().add(historyInfoMongo.getEpilogue3Content());
         }
 
+
+
         GameTitleResponse fastApiResponse = fastApiService.title(fastApiRequest);
 
         List<String> titles = fastApiResponse.getTitles();
-        if (titles != null && !titles.isEmpty()) {
-            if (titles.size() > 0) historyInfoMongo.setTitle(titles.get(0));
-            if (titles.size() > 1) historyInfoMongo.setEpilogue1Title(titles.get(1));
-            if (titles.size() > 2) historyInfoMongo.setEpilogue2Title(titles.get(2));
-            if (titles.size() > 3) historyInfoMongo.setEpilogue3Title(titles.get(3));
-        }
+        if (titles.size() > 0) historyInfoMongo.setTitle(titles.get(0));
+        if (titles.size() > 1) historyInfoMongo.setEpilogue1Title(titles.get(1));
+        if (titles.size() > 2) historyInfoMongo.setEpilogue2Title(titles.get(2));
+        if (titles.size() > 3) historyInfoMongo.setEpilogue3Title(titles.get(3));
 
         HistoryRequest historyRequest = HistoryRequest.builder()
                 .thumbnailUrl(null) // 필요 시

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -527,12 +527,15 @@ public class GameSessionService {
                 fastApiRequest.setCurrentChoice(null);
                 switch (currentEventStage) {
                     case 2:
+                        gameSessionMongo.getHistoryInfo().setEpilogue1Title("Come Stage");
                         fastApiRequest.setCurrentStory(gameSessionMongo.getHistoryInfo().getEpilogue1Content());
                         break;
                     case 4:
+                        gameSessionMongo.getHistoryInfo().setEpilogue2Title("Come Stage");
                         fastApiRequest.setCurrentStory(gameSessionMongo.getHistoryInfo().getEpilogue2Content());
                         break;
                     case 6:
+                        gameSessionMongo.getHistoryInfo().setEpilogue3Title("Come Stage");
                         fastApiRequest.setCurrentStory(gameSessionMongo.getHistoryInfo().getEpilogue3Content());
                         break;
                 }

--- a/src/main/java/com/scriptopia/demo/service/GameSessionService.java
+++ b/src/main/java/com/scriptopia/demo/service/GameSessionService.java
@@ -1287,6 +1287,29 @@ public class GameSessionService {
 
         HistoryInfoMongo historyInfoMongo = gameSessionMongo.getHistoryInfo();
 
+        GameTitleRequest fastApiRequest = new GameTitleRequest();
+        if(historyInfoMongo.getBackgroundStory() != null){
+            fastApiRequest.getContents().add(historyInfoMongo.getBackgroundStory());
+        }
+        if(historyInfoMongo.getEpilogue1Title() != null && historyInfoMongo.getEpilogue1Content() != null){
+            fastApiRequest.getContents().add(historyInfoMongo.getEpilogue1Content());
+        }
+        if(historyInfoMongo.getEpilogue2Title() != null && historyInfoMongo.getEpilogue2Content() != null){
+            fastApiRequest.getContents().add(historyInfoMongo.getEpilogue2Content());
+        }
+        if(historyInfoMongo.getEpilogue3Title() != null && historyInfoMongo.getEpilogue3Content() != null){
+            fastApiRequest.getContents().add(historyInfoMongo.getEpilogue3Content());
+        }
+
+        GameTitleResponse fastApiResponse = fastApiService.title(fastApiRequest);
+
+        List<String> titles = fastApiResponse.getTitles();
+        if (titles != null && !titles.isEmpty()) {
+            if (titles.size() > 0) historyInfoMongo.setTitle(titles.get(0));
+            if (titles.size() > 1) historyInfoMongo.setEpilogue1Title(titles.get(1));
+            if (titles.size() > 2) historyInfoMongo.setEpilogue2Title(titles.get(2));
+            if (titles.size() > 3) historyInfoMongo.setEpilogue3Title(titles.get(3));
+        }
 
         HistoryRequest historyRequest = HistoryRequest.builder()
                 .thumbnailUrl(null) // 필요 시

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -350,14 +350,14 @@
         };
 
         // 게임 히스토리 API 호출
-        const loadGameHistory = async (gameId) => {
+        const loadGameHistory = async () => {
             if (!accessToken) {
                 alert('로그인 필요');
                 return;
             }
 
             try {
-                const history = await safeFetch(null, `/api/v1/games/${gameId}/history`, {
+                const history = await safeFetch(null, `/api/v1/games/sss/history`, {
                     method: 'POST',
                     headers: { 'Authorization': 'Bearer ' + accessToken }
                 });
@@ -619,7 +619,7 @@
                 gameOverBtn.className = 'btn';
                 gameOverBtn.textContent = '게임 패배 - 결과 보기';
                 gameOverBtn.addEventListener('click', async () => {
-                    const history = await loadGameHistory(gameId);
+                    const history = await loadGameHistory();
                     showHistoryModal(history); // ✅ 모달로 표시
                 });
                 choiceContainer.appendChild(gameOverBtn);
@@ -632,7 +632,7 @@
                     gameClearBtn.className = 'btn';
                     gameClearBtn.textContent = '게임 승리 - 결과 보기';
                     gameClearBtn.addEventListener('click', async () => {
-                        const history = await loadGameHistory(gameId);
+                        const history = await loadGameHistory();
                         showHistoryModal(history); // ✅ 모달로 표시
                     });
                     choiceContainer.appendChild(gameClearBtn);


### PR DESCRIPTION
## 📑 기능 설명  
게임 완료 시 특정 빅 이벤트(2, 4, 6번 이벤트)가 완료되었을 경우에만 에필로그를 생성하도록 합니다.  
에필로그 생성 여부는 `epilogueTitle` 값으로 확인하며, 초기에는 `null` 상태에서 빅 이벤트 완료 시 다른 값으로 변경됩니다.  

## ✅ 작업할 내용  
- [x] 게임 완료 시 빅 이벤트 완료 여부 확인 로직 추가  
- [x] 이벤트 번호 2, 4, 6 완료 시 `epilogueTitle` 값을 null → 특정 값으로 업데이트  
- [x] 에필로그 타이틀이 없으면 생성하지 않고, 값이 존재하면 에필로그 생성  
- [x] 게임 결과 응답 DTO에 `epilogueTitle` 포함  
- [x] 단위 테스트 및 통합 테스트 작성  

## 🎈 기대 효과  
- 에필로그가 무조건 생성되지 않고, 특정 조건(빅 이벤트 완료)에 따라 생성됨  
- 클라이언트에서 `epilogueTitle` 값 유무로 에필로그 생성 여부를 판단 가능  
- 스토리 몰입감 및 이벤트 기반 서사 강화  

## 📎 추가 정보  
- 적용 대상 이벤트 번호: **2, 4, 6**  
- 기본값: `epilogueTitle = null`  
- 조건 충족 시: `epilogueTitle = "에필로그 제목 예시"`  
